### PR TITLE
[codex] Prepare result contract tooling release candidate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,32 @@
+# Convex Database Chat
+
+Convex Database Chat lets apps expose app-owned data access tools to a chat assistant while the library owns generic chat, tool, and result semantics.
+
+## Language
+
+**Standard Result Contract**:
+A generic tool-result envelope whose metadata tells the assistant how complete, scoped, counted, sampled, truncated, and paginated a specific tool result is.
+_Avoid_: Sift result contract, app result shape
+
+**Tool Result**:
+The JSON-serializable value returned by an app-owned tool handler after the assistant calls a tool.
+_Avoid_: response, payload
+
+**Tool Capability**:
+The model-visible description of what a tool can do before it is called, including its arguments, handler, and generic reliability kind.
+_Avoid_: tool API, function schema
+
+## Relationships
+
+- A **Tool Capability** produces a **Tool Result** when the assistant calls it.
+- A **Standard Result Contract** is an optional shape for a **Tool Result**.
+- A **Standard Result Contract** describes a specific call; **Tool Capability** metadata describes the default expectation before a call.
+
+## Example Dialogue
+
+> **Dev:** "Can the assistant count matching records from a paginated list?"
+> **Domain expert:** "Only if the **Tool Result** uses the **Standard Result Contract** and includes an exact `meta.count`; otherwise it should not infer totals from row length."
+
+## Flagged Ambiguities
+
+- Domain-specific examples are non-normative; the library should not name or depend on downstream app concepts.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,11 +16,16 @@ _Avoid_: response, payload
 The model-visible description of what a tool can do before it is called, including its arguments, handler, and generic reliability kind.
 _Avoid_: tool API, function schema
 
+**Tool Reliability Guidance**:
+Generic prompt guidance generated from tool metadata that teaches the assistant how to interpret count, paginated list, semantic search, unknown, and standard-contract results.
+_Avoid_: app prompt, domain prompt
+
 ## Relationships
 
 - A **Tool Capability** produces a **Tool Result** when the assistant calls it.
 - A **Standard Result Contract** is an optional shape for a **Tool Result**.
 - A **Standard Result Contract** describes a specific call; **Tool Capability** metadata describes the default expectation before a call.
+- **Tool Reliability Guidance** is derived from **Tool Capability** metadata, but **Tool Result** metadata wins for a specific call.
 
 ## Example Dialogue
 

--- a/DATABASE_CHAT_RESULT_CONTRACT_SPEC.md
+++ b/DATABASE_CHAT_RESULT_CONTRACT_SPEC.md
@@ -1,5 +1,9 @@
 # Convex Database Chat Result Contracts
 
+Status: implemented on `arch/result-contract-tooling-review` as a vertical
+slice covering result contracts, typed tool builders, tool reliability metadata,
+and automatic prompt guidance.
+
 ## Context
 
 This spec captures a proposed upstream feature for Convex Database Chat. It is motivated by a generic failure mode observed in downstream apps: users ask factual questions that combine totals, filtered lists, and follow-up pagination.

--- a/DATABASE_CHAT_RESULT_CONTRACT_SPEC.md
+++ b/DATABASE_CHAT_RESULT_CONTRACT_SPEC.md
@@ -1,0 +1,1412 @@
+# Convex Database Chat Result Contracts
+
+## Context
+
+This spec captures a proposed upstream feature for Convex Database Chat. It is motivated by a generic failure mode observed in downstream apps: users ask factual questions that combine totals, filtered lists, and follow-up pagination.
+
+- "How many records match this filter?"
+- "Show me the matching records."
+- "Show me more."
+
+The failure mode is that an LLM may confuse a limited list, semantic top-N result, or capped scan with a complete answer. Convex Database Chat can reduce this risk by standardizing result metadata and generic prompt behavior, while each app still owns its domain-specific queries and privacy rules.
+
+Domain-specific examples in this document are non-normative. The library should not know about any particular downstream product, schema, workflow, or business object.
+
+## Goal
+
+Add a standard result contract for tool outputs so the model can distinguish:
+
+- A deterministic count from a page of rows.
+- A complete row set from a paginated subset.
+- A deterministic page from a semantic/vector sample.
+- A broad answer from a narrower scoped answer.
+
+This is especially important when a user asks for both a count and a list. For example, if there are 200 matching records for a normalized location filter, the assistant should be able to say:
+
+> There are 200 matching records for Boston, MA. Here are the first 20.
+
+Then, if the user asks "show me more," the assistant should call the same paginated list tool with the returned cursor.
+
+## Non-Goals
+
+Convex Database Chat should not implement app-specific data access.
+
+For any app, the app still owns:
+
+- The Convex queries over its own tables.
+- Auth and app-owned scope enforcement.
+- Domain-specific normalization and matching.
+- Privacy filtering and safe row shapes.
+- Index choices and sort order.
+- Which tools are exposed to the model.
+
+The library should own the shared contract, tool-builder ergonomics, and generic prompt rules for interpreting metadata.
+
+## Result Shape
+
+Proposed tool output shape:
+
+```ts
+type DatabaseChatToolResult<Row = unknown> = {
+  data: Row[];
+  meta: DatabaseChatResultMeta;
+};
+```
+
+V1 should use this single envelope for count, list, semantic search, and detail-style outputs. Separate top-level result shapes are deferred unless the standard envelope proves ambiguous in real integrations.
+
+## Result Contract Module Scope
+
+The first implementation slice should introduce a narrow result contract module at `convex/component/resultContract.ts`. Its interface should own only the standard result contract types and invariants:
+
+- `DatabaseChatToolResult<Row>`
+- `DatabaseChatResultMeta`
+- `DatabaseChatScope`
+- `DatabaseChatResultValidationError`
+- `validateToolResultContract(result)`
+- `isDatabaseChatToolResult(result)`
+
+It should not own tool definitions, builder functions, prompt guidance text, cursor session state, app-specific row helpers, or Convex validators for app handlers.
+
+The module should be TypeScript-only in v1. It may expose lightweight runtime validation for plain JSON values, but it should not expose Convex `v` validators. App handlers own any Convex `args` or `returns` validators they need.
+
+Later packaging can decide whether to re-export these types from `src/index.ts` or another public entry. Do not let packaging concerns broaden the module's first interface.
+
+Do not include result constructors in the contract-only slice. Helpers such as `createCountResult`, `createPaginatedListResult`, or `createSemanticSearchResult` belong with typed builders or a later app-facing helper slice if real usage shows they add leverage.
+
+Validation should be non-throwing by default:
+
+```ts
+type DatabaseChatResultValidationError = {
+  code: string;
+  path: string;
+  message: string;
+};
+
+function validateToolResultContract(
+  result: unknown
+): DatabaseChatResultValidationError[];
+
+function isDatabaseChatToolResult(
+  result: unknown
+): result is DatabaseChatToolResult;
+```
+
+Returning all structured errors is better for tests and optional future execution checks than throwing on the first issue. The `isDatabaseChatToolResult` type guard should be derived from validation, equivalent to `validateToolResultContract(result).length === 0`, so the module has one definition of validity.
+
+The first slice should export and test validation, but should not call `validateToolResultContract` from `chat.send`, `toolExecution`, or `DatabaseChatClient` execution paths yet. Runtime integration needs separate policy decisions about whether validation failures should be logged, ignored, exposed for debugging, or fail a tool call.
+
+Required invariants:
+
+- `returned` must equal `data.length`.
+- `count`, when present, means a known exact count for the same `scope` and `appliedFilters`.
+- Approximate counts are out of scope for v1. If an app cannot cheaply provide an exact count, it should omit `count` rather than guess.
+- `data` should remain bounded by the tool's `limit` or app-enforced maximum, even when `count` is very large.
+- Result metadata is authoritative for the specific call. Tool metadata describes the default expectation for the tool, but prompt guidance should follow `result.meta` when a standard result contract is present.
+
+V1 validation should check only contract-level invariants:
+
+- The result is an object with a `data` array and `meta` object.
+- `meta.returned === data.length`.
+- `meta.scope` is required and must be an object with non-empty string `type`.
+- `count`, when present, is a non-negative safe integer.
+- `returned` is a non-negative safe integer.
+- `exhaustive`, `truncated`, and `sampled` are booleans.
+- `sampled === true` must not also report `exhaustive === true`.
+- `sampled === true` must not include `count` in v1.
+- `pagination.hasMore === true` requires non-empty `nextCursor`.
+- `pagination` is valid only when `sampled === false`.
+- `pagination.hasMore === true` must not also report `exhaustive === true`.
+- `exhaustive === true` must not also report `truncated === true`.
+- `appliedFilters` may be absent; if present, it must be a non-array object.
+- `truncationReason` must be present as a non-empty string when `truncated === true`; when `truncated === false`, it may be absent, but if present it must still be non-empty.
+- `sampleMethod` must be present as a non-empty string when `sampled === true`; when `sampled === false`, it may be absent, but if present it must still be non-empty.
+- `sampled` and `truncated` are independent except that `sampled === true` must not also report `exhaustive === true`.
+- `pagination.cursor` may be absent, `null`, or a string.
+- `pagination.nextCursor` may be absent or `null` only when `hasMore === false`; it must be a non-empty string when `hasMore === true`.
+- `pagination.pageSize` may be absent; if present, it must be a non-negative safe integer.
+- `scope.id` and `scope.label` may be absent; if present, they must be non-empty strings.
+
+V1 validation should not check app-owned or semantic facts:
+
+- Whether `count` is actually exact.
+- Whether `scope.type` is a known enum.
+- Whether `appliedFilters` match the user's words.
+- Whether `truncationReason` or `sampleMethod` values are from a fixed enum.
+- Whether row fields are safe or complete.
+
+For count-only tools, `data` can be an empty array:
+
+```ts
+{
+  data: [],
+  meta: {
+    count: 200,
+    returned: 0,
+    exhaustive: true,
+    truncated: false,
+    sampled: false,
+    scope: { type: "workspace", id: "workspace_123", label: "Example Workspace" },
+    appliedFilters: { location: "Boston, MA" }
+  }
+}
+```
+
+## Metadata Fields
+
+### `scope`
+
+The structured universe the tool queried.
+
+V1 should use an object, not a plain string:
+
+```ts
+export type DatabaseChatScope = {
+  type: string;
+  id?: string;
+  label?: string;
+};
+```
+
+The library should not define or interpret built-in `type` values in v1. Apps own the meaning of scope types, ids, and labels. Apps may use values such as `tenant`, `org`, `workspace`, `project`, `user`, `conversation`, `global`, or any other vocabulary that matches their domain.
+
+Examples:
+
+```ts
+scope: { type: "global" }
+scope: { type: "workspace", id: "workspace_123", label: "Example Workspace" }
+scope: { type: "conversation" }
+scope: { type: "custom", label: "Current user access scope" }
+```
+
+Value:
+
+- Prevents ambiguous answers like "200 records" when the real answer is "200 records across a broad app-owned scope" or "200 records inside this narrower scope."
+- Lets the assistant include scope in the answer when helpful.
+- `scope` is required for standard result contracts. Apps should avoid `scope: { type: "unknown" }` except as a migration fallback.
+- Future prompt guidance should tell the assistant to treat answers as applying only to `meta.scope`, and to include scope in the answer when it prevents ambiguity.
+
+### `appliedFilters`
+
+The filters the backend actually applied after validation and normalization.
+
+Example:
+
+```ts
+appliedFilters: {
+  location: "Boston, MA",
+  status: "analyzed",
+  minScore: 70
+}
+```
+
+Value:
+
+- Confirms what the backend understood.
+- Allows apps to normalize user input, such as "Boston" to "Boston, MA."
+- Helps the assistant answer precisely without guessing.
+- `appliedFilters` is optional. Some tools have no filters, some tools are scoped entirely by app context, and some apps may not want to expose normalized filter details in every result.
+
+### `count`
+
+The exact total number of matching records in the queried scope, when known.
+
+Example:
+
+```ts
+count: 200
+returned: 20
+```
+
+Value:
+
+- The assistant should use `meta.count` for "how many" questions.
+- The assistant should not infer counts from `data.length` when `count` is present or when rows are paginated/sampled.
+- `count` can be much larger than `returned`. A result with `count: 50000` and `returned: 20` is valid and should be answered as "50,000 matching records; here are the first 20."
+- Paginated list tools may include `count` only when it is the exact total for the same scope and filters as the returned page.
+- Semantic search tools should omit `count` in v1. Do not return `count: undefined`; absence means unknown or not applicable.
+- Sampled results must not include `count` in v1. If an app needs both an exact count and sampled examples, it should use separate tool calls or a deterministic list result.
+
+### `returned`
+
+The number of rows included in `data`.
+
+Keep the field name `returned`. Do not rename it to `rowCount` or `dataCount`; `returned` stays generic across rows, records, search results, and detail-like outputs.
+
+Example:
+
+```ts
+returned: 20
+```
+
+Value:
+
+- Makes it explicit that the tool returned 20 rows, even if 200 matched.
+- Must equal `data.length`.
+- Must equal the actual returned JSON `data.length`; privacy filtering, internal row filtering, or row hiding must happen before constructing `data`.
+- Useful in prompt guidance: "Here are the first 20" rather than implying the list is complete.
+
+### `exhaustive`
+
+Whether the result is complete for the requested operation.
+
+For list-like results, `exhaustive` means `data` includes every matching record in the queried scope. For count-only results, `data` is intentionally empty, but the result may still be exhaustive because `meta.count` is the complete answer.
+
+Examples:
+
+```ts
+count: 14
+returned: 14
+exhaustive: true
+```
+
+```ts
+count: 200
+returned: 20
+exhaustive: false
+```
+
+Value:
+
+- If `exhaustive` is false, the assistant should not summarize the complete population from `data` alone.
+- The assistant can still answer counts from `meta.count`.
+- `pagination` may be present when `exhaustive === true` if `pagination.hasMore === false`, such as a final page or a small result set that fits in one page.
+- `pagination.hasMore === true` implies `exhaustive === false`.
+- Count-only tools should use `data: []`, `returned: 0`, exact `count`, and `exhaustive: true`.
+
+### `truncated`
+
+Whether the tool intentionally omitted matching rows or omitted parts of returned values due to size, page, model, policy, timeout, or app cost limits.
+
+Examples:
+
+```ts
+truncated: true
+truncationReason: "row_limit"
+```
+
+```ts
+truncated: true
+truncationReason: "field_size"
+```
+
+Value:
+
+- Makes incomplete row data explicit.
+- Helps avoid pretending a row contains full analysis when fields were omitted or shortened.
+- Covers both row-set truncation and field/content truncation in v1. `truncationReason` disambiguates the cause.
+- If `truncated === true`, `truncationReason` must be a non-empty string.
+- Do not validate `truncationReason` as an enum in v1. Example app-owned values include `row_limit`, `field_size`, `token_budget`, `semantic_top_k_limit`, `max_limit_clamped`, `privacy_redaction`, `timeout`, and `cost_limit`.
+
+### `sampled`
+
+Whether `data` is a heuristic or representative subset rather than a deterministic page.
+
+Examples:
+
+```ts
+sampled: true
+sampleMethod: "semantic_top_k"
+```
+
+```ts
+sampled: false
+pagination: { hasMore: true, nextCursor: "abc123" }
+```
+
+Value:
+
+- Distinguishes vector search top-N from deterministic pagination.
+- The assistant should never answer "how many" from sampled result length.
+- Sampled results must not include `count` in v1.
+- If `sampled === true`, `sampleMethod` must be a non-empty string.
+- Do not validate `sampleMethod` as an enum in v1. Example app-owned values include `semantic_top_k`, `random_sample`, and `representative_sample`.
+- Top-K means the tool returns the K best-scoring results by relevance, not every matching result.
+- A semantic top-K result should use `sampled: true` because it is a relevance sample, but it does not have to use `truncated: true` unless the app also wants to report a hard row, field, token, policy, timeout, or cost limit.
+
+### `pagination`
+
+Cursor metadata for deterministic list tools.
+
+Example:
+
+```ts
+pagination: {
+  cursor: null,
+  hasMore: true,
+  nextCursor: "abc123",
+  pageSize: 20
+}
+```
+
+Value:
+
+- Allows the assistant to continue listing results when the user asks "show more."
+- Gives the assistant enough context to say "Here are the first 20."
+- Keeps deterministic pagination separate from sampled semantic search.
+- Handles large result sets by limiting `data` to one deterministic page. The `count` may be thousands or millions, but the returned rows should still be capped by `limit`, `pageSize`, and the tool builder's max limit.
+- `nextCursor` should be opaque to the model. The assistant should pass it back unchanged when continuing the same list.
+- If `hasMore` is true, `nextCursor` must be present.
+- `hasMore === true` must not be combined with `exhaustive === true`.
+- V1 pagination follow-up is best effort: the model should use `nextCursor` from recent tool results. The library should not persist separate pagination session state in the first slice.
+
+Deferred durable pagination state:
+
+- The library may later store active pagination state per conversation to support "show more" after long gaps, after the original tool result leaves the model context, or when multiple paginated lists are active.
+- A durable design would need to define pagination sessions, disambiguation rules, cursor expiry, and how stored state is exposed back to the model.
+- Do not add this state management to v1 unless immediate follow-up via recent tool results proves insufficient.
+
+## Full Example: Count and First Page
+
+Input tool call:
+
+```ts
+listRecords({
+  filters: { location: "Boston, MA" },
+  limit: 20
+})
+```
+
+Output:
+
+```ts
+{
+  data: [
+    {
+      id: "record_1",
+      title: "Example record",
+      location: "Boston, MA",
+      status: "active",
+      viewUrl: "/records/record_1"
+    }
+  ],
+  meta: {
+    scope: { type: "workspace", id: "workspace_123", label: "Example Workspace" },
+    appliedFilters: { location: "Boston, MA" },
+    count: 200,
+    returned: 20,
+    exhaustive: false,
+    truncated: true,
+    truncationReason: "row_limit",
+    sampled: false,
+    pagination: {
+      cursor: null,
+      hasMore: true,
+      nextCursor: "abc123",
+      pageSize: 20
+    }
+  }
+}
+```
+
+Expected assistant behavior:
+
+> There are 200 matching records for Boston, MA. Here are the first 20.
+
+If the user asks "show more," the assistant should call:
+
+```ts
+listRecords({
+  filters: { location: "Boston, MA" },
+  cursor: "abc123",
+  limit: 20
+})
+```
+
+## Full Example: Semantic Search
+
+Input tool call:
+
+```ts
+semanticSearchRecords({
+  query: "records related to database reliability",
+  limit: 20
+})
+```
+
+Output:
+
+```ts
+{
+  data: [
+    {
+      id: "record_1",
+      title: "Database reliability note",
+      snippet: "..."
+    }
+  ],
+  meta: {
+    scope: { type: "workspace", id: "workspace_123", label: "Example Workspace" },
+    appliedFilters: { query: "records related to database reliability" },
+    returned: 20,
+    exhaustive: false,
+    truncated: true,
+    truncationReason: "semantic_top_k_limit",
+    sampled: true,
+    sampleMethod: "semantic_top_k"
+  }
+}
+```
+
+Expected assistant behavior:
+
+- Do not answer "There are 20."
+- Say these are relevant records or search results.
+- Use deterministic count/list tools for factual count questions.
+
+## Library Responsibilities
+
+Convex Database Chat should provide:
+
+### 1. Public Result Types
+
+Export types such as:
+
+```ts
+export type DatabaseChatToolResult<Row> = {
+  data: Row[];
+  meta: DatabaseChatResultMeta;
+};
+
+export type DatabaseChatResultMeta = {
+  scope: DatabaseChatScope;
+  appliedFilters?: Record<string, unknown>;
+  count?: number;
+  returned: number;
+  exhaustive: boolean;
+  truncated: boolean;
+  truncationReason?: string;
+  sampled: boolean;
+  sampleMethod?: string;
+  pagination?: {
+    cursor?: string | null;
+    hasMore: boolean;
+    nextCursor?: string | null;
+    pageSize?: number;
+  };
+};
+```
+
+### 2. Tool Builders With Metadata Semantics
+
+Potential helper APIs:
+
+```ts
+defineCountTool(...)
+definePaginatedListTool(...)
+defineSemanticSearchTool(...)
+defineDetailTool(...)
+```
+
+These should generate:
+
+- LLM parameter schema.
+- Tool descriptions.
+- Reliability metadata such as deterministic vs sampled.
+- Standard prompt hints for result interpretation.
+
+### 3. Prompt Guidance
+
+The component should inject reusable prompt guidance automatically, with an app-facing override or disable option:
+
+- Use `meta.count` for count questions.
+- Never infer counts from `data.length` when `sampled`, `truncated`, or `exhaustive === false`.
+- If `pagination.hasMore` is true, say the rows are the first page.
+- If the user asks for more, call the same tool with `pagination.nextCursor`.
+- If `scope` is narrow, include the scope in the answer.
+- If `appliedFilters` differ from the user's wording due to normalization, mention the normalized filter when helpful.
+
+### 4. Optional Validation Helpers
+
+The library can include runtime helpers to validate that tool results match the contract:
+
+```ts
+validateToolResultContract(result)
+```
+
+Potential checks:
+
+- `returned === data.length`.
+- `sampled === true` should not also report `exhaustive === true`.
+- `pagination.hasMore === true` should include `nextCursor`.
+- `exhaustive === true` should imply `truncated === false`.
+
+## App Responsibilities
+
+Apps should implement:
+
+- The handler that returns the contract.
+- Domain-specific filters.
+- Cursor queries.
+- Counts.
+- Safe row shapes.
+- Result sorting.
+- Privacy boundaries.
+
+For example, an app would implement a handler like:
+
+```ts
+export const listRecords = internalQuery({
+  args: {
+    scopeId: v.string(),
+    filters: recordFilterValidator,
+    limit: v.optional(v.number()),
+    cursor: v.optional(v.string())
+  },
+  handler: async (ctx, args): Promise<DatabaseChatToolResult<RecordRow>> => {
+    // App-owned implementation:
+    // - verify app-owned scope
+    // - normalize filters
+    // - run deterministic count
+    // - run cursor-paginated list
+    // - return safe rows plus metadata
+  }
+});
+```
+
+## Recommended First Slice
+
+Start with a contract-only upstream slice:
+
+1. Export public result contract types.
+2. Export lightweight runtime validation helpers for the standard contract if the implementation remains small.
+3. Add tests showing:
+   - `returned === data.length`;
+   - count-only result with `data: []`, exact `count`, and `returned: 0`;
+   - deterministic first page with `count: 200`, `returned: 20`, `hasMore: true`;
+   - semantic top-K with `sampled: true` and no `count`.
+
+Defer typed builders and component-injected prompt guidance to separate slices unless a later vertical-slice plan deliberately groups them.
+
+---
+
+# Typed Tool Builders
+
+## Context
+
+The result contract solves how tool outputs should be interpreted. Typed tool builders solve a different but related problem: app authors currently hand-write several representations of the same tool capability.
+
+For each tool, an app may need to keep these aligned:
+
+- LLM-facing JSON schema.
+- Tool description.
+- Tool reliability metadata.
+- Handler argument expectations.
+- Result contract expectations.
+- System prompt guidance.
+- App-owned Convex validators.
+
+This is a drift risk. The library should make common tool kinds easy to define without taking ownership of app-specific queries.
+
+## Goal
+
+Add public builder functions that let app authors define tool capabilities once. The builders should generate:
+
+- The existing `DatabaseChatTool` shape consumed by the component.
+- LLM JSON schema for tool calling.
+- Tool reliability metadata.
+- Standard prompt guidance.
+- TypeScript inference helpers for model args, handler args, and result shape.
+
+The builders should not generate or execute app-specific database queries.
+
+## Public API Choice
+
+Use split public functions:
+
+```ts
+defineCountTool(...)
+definePaginatedListTool(...)
+defineSemanticSearchTool(...)
+```
+
+These should be thin wrappers over one internal discriminated core, but the public API should stay explicit.
+
+Rationale:
+
+- The function name carries the truth contract.
+- `defineCountTool` means totals.
+- `definePaginatedListTool` means deterministic rows with cursor pagination.
+- `defineSemanticSearchTool` means relevant top-K results, not exhaustive counts.
+- This reduces the chance that app authors accidentally configure contradictory reliability flags.
+
+Avoid a loose generic API like:
+
+```ts
+defineTool({ sampled: true, supportsCount: false, ... })
+```
+
+That pushes too much correctness burden onto each app.
+
+## Tool Kinds
+
+Internally, the library can still represent these as tool kinds:
+
+```ts
+type ToolKind = "count" | "paginated_list" | "semantic_search";
+```
+
+Each kind should imply different defaults:
+
+```ts
+// count
+{
+  supportsCount: true,
+  paginated: false,
+  sampled: false
+}
+
+// paginated_list
+{
+  supportsCount: true,
+  paginated: true,
+  sampled: false
+}
+
+// semantic_search
+{
+  supportsCount: false,
+  paginated: false,
+  sampled: true
+}
+```
+
+## Filters
+
+Filters must be fully generic and app-defined. The library should not know about domain-specific concepts such as locations, scores, accounts, jobs, applications, tickets, or any other app-owned entity.
+
+Filters should be flat and optional by default.
+
+Example:
+
+```ts
+filters: {
+  status: enumFilter({
+    values: ["active", "inactive", "archived"] as const,
+    description: "Record status."
+  }),
+  createdAfter: numberFilter({
+    description: "Only include records created after this timestamp."
+  })
+}
+```
+
+Generated model args:
+
+```ts
+{
+  filters?: {
+    status?: "active" | "inactive" | "archived";
+    createdAfter?: number;
+  };
+}
+```
+
+### Filter Defaults
+
+- Filters are optional unless marked `required: true`.
+- Filters are nested under `filters`; do not flatten them at the top level.
+- Nested filters and boolean query logic are out of scope for v1.
+- Range filters should be represented as app-defined flat filters, such as `createdAfter` and `createdBefore`, rather than a nested range object.
+
+## Builder Limits
+
+Builders should always have effective default and max limits, but app-provided limit config should be optional because the library supplies conservative defaults.
+
+Recommended defaults:
+
+```ts
+definePaginatedListTool(...) -> {
+  defaultLimit: 20,
+  maxLimit: 100
+}
+
+defineSemanticSearchTool(...) -> {
+  defaultLimit: 10,
+  maxLimit: 50
+}
+```
+
+Apps can override these defaults:
+
+```ts
+definePaginatedListTool({
+  // ...
+  pagination: {
+    defaultLimit: 25,
+    maxLimit: 75
+  }
+})
+```
+
+Count tools should not expose `limit`.
+
+Builder behavior:
+
+- Expose `limit?: number` to the model for paginated list and semantic search tools.
+- Include the effective default and max in the generated JSON schema description.
+- Extend JSON schema with numeric constraints if the local `ToolParameterSchema` supports them; otherwise describe the bounds in plain language.
+- Generated helpers may clamp model-provided `limit` before invoking the handler, but app handlers must still enforce max limits because the app owns data access and cost controls.
+
+## Filter Helpers
+
+Recommended v1 helper names and signatures:
+
+```ts
+function stringFilter(options?: {
+  description?: string;
+  required?: boolean;
+}): StringFilter;
+
+function numberFilter(options?: {
+  description?: string;
+  required?: boolean;
+  min?: number;
+  max?: number;
+}): NumberFilter;
+
+function booleanFilter(options?: {
+  description?: string;
+  required?: boolean;
+}): BooleanFilter;
+
+function enumFilter<const Values extends readonly string[]>(options: {
+  values: Values;
+  description?: string;
+  required?: boolean;
+}): EnumFilter<Values>;
+```
+
+Defer `idFilter` in v1. App-specific ids can be modeled as strings until there is a clear need for a Convex-aware id helper.
+
+## Injected Args
+
+Some handler args should be required by the app but invisible to the model. Examples include tenant ids, org ids, user ids, and external auth ids.
+
+Use typed injected args, not just a string list:
+
+```ts
+injectedArgs: {
+  orgId: injectedString({
+    description: "Current organization id, injected by the app."
+  }),
+  externalId: injectedString({
+    description: "Current external user id, injected by the app."
+  })
+}
+```
+
+Recommended v1 helper:
+
+```ts
+function injectedString(options?: {
+  description?: string;
+}): InjectedArg<"string">;
+```
+
+Why this matters:
+
+- The model should not choose injected values.
+- The LLM JSON schema should not expose injected values.
+- The handler should still receive injected values through `toolContext`.
+- Type inference should distinguish model args from handler args.
+
+## TypeScript Inference
+
+Expose these inference helpers:
+
+```ts
+type InferToolModelArgs<Tool> = ...
+type InferToolHandlerArgs<Tool> = ...
+type InferToolResult<Tool> = ...
+```
+
+For a paginated list tool:
+
+```ts
+const listRecordsTool = definePaginatedListTool<RecordRow>({
+  name: "listRecords",
+  description: "List records matching deterministic filters.",
+  handler: handles.listRecords,
+  filters: {
+    status: enumFilter({
+      values: ["active", "inactive"] as const
+    })
+  },
+  injectedArgs: {
+    tenantId: injectedString()
+  },
+  pagination: {
+    defaultLimit: 20,
+    maxLimit: 100
+  }
+});
+```
+
+`InferToolModelArgs<typeof listRecordsTool>` should infer:
+
+```ts
+{
+  filters?: {
+    status?: "active" | "inactive";
+  };
+  limit?: number;
+  cursor?: string;
+}
+```
+
+`InferToolHandlerArgs<typeof listRecordsTool>` should infer:
+
+```ts
+{
+  filters?: {
+    status?: "active" | "inactive";
+  };
+  limit?: number;
+  cursor?: string;
+  tenantId: string;
+}
+```
+
+`InferToolResult<typeof listRecordsTool>` should infer:
+
+```ts
+DatabaseChatToolResult<RecordRow>
+```
+
+## Convex Validators
+
+Do not generate Convex `v` validators in v1.
+
+The builders should generate LLM JSON schema because model tool calling requires JSON schema. Convex validators are a separate runtime validation layer owned by the app.
+
+Reasons to defer Convex validator generation:
+
+- It couples the tool builder more tightly to Convex validator APIs.
+- Complex validators, unions, optional/null behavior, and ids need more design work.
+- The first slice can deliver value through JSON schema, metadata, prompt guidance, and TypeScript inference.
+
+Apps can still write Convex validators manually:
+
+```ts
+export const listRecords = internalQuery({
+  args: {
+    filters: v.optional(v.object({
+      status: v.optional(v.union(v.literal("active"), v.literal("inactive")))
+    })),
+    limit: v.optional(v.number()),
+    cursor: v.optional(v.string()),
+    tenantId: v.string()
+  },
+  handler: async (ctx, args): Promise<InferToolResult<typeof listRecordsTool>> => {
+    // app-owned implementation
+  }
+});
+```
+
+Convex validator generation can be considered later as an optional helper if duplication becomes painful.
+
+## Prompt Guidance
+
+Tool reliability guidance should be injected automatically by the component based on builder metadata.
+
+For example, the component can append guidance like:
+
+- Count tools provide totals; use `meta.count` for "how many" questions.
+- Paginated list tools return deterministic rows and may include only the first page.
+- If `meta.pagination.hasMore` is true, tell the user this is a page and use `nextCursor` if they ask for more.
+- Semantic search tools are sampled top-K results and must not be used for factual counts.
+- Never infer totals from `data.length` when `sampled`, `truncated`, or `exhaustive === false`.
+
+Default should be automatic, with an escape hatch:
+
+```ts
+includeToolReliabilityGuidance?: boolean;
+```
+
+or:
+
+```ts
+toolGuidance?: "auto" | "disabled";
+```
+
+## Effect
+
+Do not require Effect for v1 unless the Convex Database Chat repo already wants it.
+
+Effect could be useful later for:
+
+- Structured result-contract validation.
+- Typed parse errors.
+- Contract validation tests.
+- Retry, timeout, or cancellation policies around external model calls.
+
+Effect is not necessary for:
+
+- Simple builder functions.
+- JSON schema generation.
+- Cursor pagination metadata.
+- Basic prompt guidance formatting.
+
+For v1, use lightweight runtime validation and normal Vitest tests. If validation grows more complex, Effect Schema could be considered as an optional internal implementation detail.
+
+## Example: Generic App Tool
+
+```ts
+const listRecordsTool = definePaginatedListTool<RecordRow>({
+  name: "listRecords",
+  description: "List records matching deterministic filters.",
+  handler: handles.listRecords,
+  filters: {
+    status: enumFilter({
+      values: ["active", "inactive", "archived"] as const,
+      description: "Record status."
+    }),
+    createdAfter: numberFilter({
+      description: "Only include records created after this timestamp."
+    })
+  },
+  injectedArgs: {
+    tenantId: injectedString({
+      description: "Current tenant id, injected by the app."
+    })
+  },
+  pagination: {
+    defaultLimit: 20,
+    maxLimit: 100
+  }
+});
+```
+
+The LLM sees:
+
+```ts
+{
+  filters?: {
+    status?: "active" | "inactive" | "archived";
+    createdAfter?: number;
+  };
+  limit?: number;
+  cursor?: string;
+}
+```
+
+The handler receives:
+
+```ts
+{
+  filters?: {
+    status?: "active" | "inactive" | "archived";
+    createdAfter?: number;
+  };
+  limit?: number;
+  cursor?: string;
+  tenantId: string;
+}
+```
+
+## Example: Domain App Tool
+
+A downstream app could use the same generic API with app-owned filter names:
+
+```ts
+const listRecordsTool = definePaginatedListTool<RecordRow>({
+  name: "listRecords",
+  description: "List records matching deterministic filters.",
+  handler: handles.listRecords,
+  filters: {
+    location: stringFilter({
+      description: "Record location. The app normalizes this before querying."
+    }),
+    status: enumFilter({
+      values: ["active", "inactive", "archived"] as const,
+      description: "Record status."
+    }),
+    minScore: numberFilter({
+      min: 0,
+      max: 100,
+      description: "Minimum app-defined score."
+    }),
+    maxScore: numberFilter({
+      min: 0,
+      max: 100,
+      description: "Maximum app-defined score."
+    })
+  },
+  injectedArgs: {
+    orgId: injectedString(),
+    userId: injectedString(),
+    externalId: injectedString()
+  },
+  pagination: {
+    defaultLimit: 20,
+    maxLimit: 50
+  }
+});
+```
+
+The library remains agnostic. It only sees filter names, basic schema types, injected args, pagination config, and reliability metadata. The app still owns the Convex query, domain normalization, privacy-safe rows, and indexes.
+
+## Recommended First Slice
+
+Builder work should be implemented after the contract-only slice.
+
+1. Export split builder functions:
+   - `defineCountTool`
+   - `definePaginatedListTool`
+   - `defineSemanticSearchTool`
+2. Export filter helpers:
+   - `stringFilter`
+   - `numberFilter`
+   - `booleanFilter`
+   - `enumFilter`
+   - `injectedString`
+3. Generate LLM JSON schema with model args under `filters`.
+4. Exclude `injectedArgs` from the LLM JSON schema while including them in handler arg inference.
+5. Export inference helpers:
+   - `InferToolModelArgs`
+   - `InferToolHandlerArgs`
+   - `InferToolResult`
+6. Attach reliability metadata to built tools, but leave component prompt-guidance injection to the prompt-guidance slice unless the chosen vertical slice explicitly includes both.
+7. Do not generate Convex validators yet.
+8. Add tests for:
+   - optional filters by default;
+   - required filters;
+   - enum inference;
+   - injected args excluded from model schema;
+   - injected args included in handler arg inference;
+   - paginated list metadata;
+   - semantic search metadata.
+
+---
+
+# Tool Reliability Metadata and Prompt Guidance
+
+## Context
+
+The result contract describes what happened in a specific tool call. Tool reliability metadata describes what kind of tool this is expected to be before a call is made.
+
+This metadata should let Convex Database Chat automatically add generic prompt guidance such as:
+
+- Use count tools for totals.
+- Treat paginated list tools as deterministic pages.
+- Treat semantic search tools as sampled top-K results.
+- Do not infer totals from row count unless the result includes an explicit `meta.count`.
+
+## Design Principle
+
+Keep public metadata small and deterministic.
+
+Avoid exposing a loose set of overlapping flags such as:
+
+```ts
+{
+  reliability: "deterministic",
+  supportsCount: true,
+  sampled: false,
+  paginated: true
+}
+```
+
+Those flags can conflict or drift. For v1, expose one primary kind field and let the library derive behavior internally.
+
+## Public Metadata Shape
+
+Recommended v1 shape:
+
+```ts
+export type DatabaseChatToolKind =
+  | "count"
+  | "paginated_list"
+  | "semantic_search"
+  | "detail"
+  | "unknown";
+
+export type DatabaseChatToolMetadata = {
+  kind: DatabaseChatToolKind;
+  resultContract?: "standard";
+};
+```
+
+Built tools should attach metadata directly to the tool entity:
+
+```ts
+{
+  name: "listRecords",
+  description: "...",
+  parameters: { ... },
+  handler: "...",
+  metadata: {
+    kind: "paginated_list",
+    resultContract: "standard"
+  }
+}
+```
+
+## Derived Internal Behavior
+
+The library may derive behavior from `metadata.kind` internally:
+
+```ts
+const TOOL_KIND_BEHAVIOR = {
+  count: {
+    supportsCount: true,
+    paginated: false,
+    sampled: false
+  },
+  paginated_list: {
+    supportsCount: true,
+    paginated: true,
+    sampled: false
+  },
+  semantic_search: {
+    supportsCount: false,
+    paginated: false,
+    sampled: true
+  },
+  detail: {
+    supportsCount: false,
+    paginated: false,
+    sampled: false
+  },
+  unknown: {
+    supportsCount: false,
+    paginated: false,
+    sampled: undefined
+  }
+};
+```
+
+These booleans should be internal implementation details in v1, not public knobs.
+
+## Builder Defaults
+
+The split builders should set metadata automatically:
+
+```ts
+defineCountTool(...) -> metadata.kind = "count"
+definePaginatedListTool(...) -> metadata.kind = "paginated_list"
+defineSemanticSearchTool(...) -> metadata.kind = "semantic_search"
+```
+
+If a detail tool is added in v1 or later:
+
+```ts
+defineDetailTool(...) -> metadata.kind = "detail"
+```
+
+All builders that expect the standard result contract should set:
+
+```ts
+metadata.resultContract = "standard"
+```
+
+## Backward Compatibility
+
+Existing raw tools without metadata must continue to work.
+
+Treat missing metadata as:
+
+```ts
+metadata: {
+  kind: "unknown"
+}
+```
+
+Do not throw, fail validation, or require migration.
+
+Prompt guidance for unknown tools should be conservative:
+
+> Tools without metadata may be incomplete, sampled, or app-specific. Do not infer totals from returned row count unless the result explicitly includes `meta.count`.
+
+## Result Metadata Wins
+
+Tool metadata is the default expectation. Result metadata is the source of truth for a specific tool call.
+
+If they conflict, result metadata wins for that call.
+
+Example:
+
+```ts
+tool.metadata.kind = "paginated_list"
+result.meta.sampled = true
+```
+
+The assistant should treat the specific result as sampled because the result contract says so.
+
+This allows handlers to be precise about unusual runtime cases without requiring a large public metadata flag surface.
+
+## Prompt Guidance Injection
+
+Tool reliability guidance should be injected automatically by the component.
+
+Implement this as its own slice after result contracts and typed builders, unless the implementation plan intentionally groups builder metadata and guidance in one vertical slice.
+
+Default:
+
+```ts
+toolGuidance: "auto"
+```
+
+Override or opt out:
+
+```ts
+toolGuidance: "disabled"
+```
+
+Suggested config field:
+
+```ts
+type SendConfig = {
+  ...
+  toolGuidance?: "auto" | "disabled" | string;
+};
+```
+
+If `toolGuidance` is a string, append that custom guidance instead of generated guidance.
+
+The current component already builds a system prompt from the base prompt and tool descriptions. Reliability guidance can be appended in the same path.
+
+## Default Guidance Text
+
+Concrete v1 guidance text can be generated from the set of tool kinds present.
+
+Suggested wording:
+
+```text
+Tool result reliability:
+
+- Use count tools for factual total/count questions. Prefer `meta.count` when present.
+- Paginated list tools return deterministic rows, but may only return one page. If `meta.pagination.hasMore` is true, say that more results are available.
+- When the user asks for more results from a paginated list, call the same tool again with the previous `meta.pagination.nextCursor` and the same relevant filters.
+- Semantic search tools return sampled top-K relevance results. Do not use semantic search result length as a factual count.
+- Tools without metadata may be incomplete, sampled, or app-specific. Do not infer totals from returned row count unless the result explicitly includes `meta.count`.
+- For any standard result contract, the result metadata for that specific call is authoritative. Do not infer totals from `data.length` when `meta.sampled`, `meta.truncated`, or `meta.exhaustive === false`.
+```
+
+The exact wording can be tightened during implementation, but tests should assert the core semantics:
+
+- count questions use `meta.count`;
+- semantic search length is not a count;
+- paginated list follow-up uses `nextCursor`;
+- unknown tools are treated conservatively;
+- result metadata overrides tool kind assumptions.
+
+## Pagination Follow-Up Behavior
+
+V1 should support immediate follow-ups on a best-effort basis by relying on the model-visible recent tool result. The library should not store separate pagination sessions in v1.
+
+When a standard result contract includes:
+
+```ts
+meta.pagination = {
+  hasMore: true,
+  nextCursor: "abc123"
+}
+```
+
+The prompt should instruct the model to:
+
+1. Tell the user that only a page was shown, when relevant.
+2. Reuse the same tool, same relevant filters, and `nextCursor` if the user asks for more.
+3. Avoid restarting pagination from the first page unless the user changes filters or asks to start over.
+
+Example:
+
+User:
+
+> How many records are active?
+
+Tool returns:
+
+```ts
+{
+  data: [/* 20 rows */],
+  meta: {
+    count: 200,
+    returned: 20,
+    sampled: false,
+    exhaustive: false,
+    truncated: true,
+    pagination: {
+      hasMore: true,
+      nextCursor: "abc123"
+    }
+  }
+}
+```
+
+Assistant:
+
+> There are 200 active records. Here are the first 20.
+
+User:
+
+> Show more.
+
+Assistant should call the same tool with:
+
+```ts
+{
+  filters: { /* same relevant filters */ },
+  cursor: "abc123",
+  limit: 20
+}
+```
+
+## Unknown Tools
+
+Unknown tools should not fail. They should simply receive conservative guidance.
+
+Rules:
+
+- If a raw tool returns a standard result contract, use its `meta`.
+- If a raw tool does not return a standard result contract, do not infer count/exhaustiveness from row length.
+- App-specific prompt text can still explain raw tool behavior, but the library should not assume it.
+
+## Trade-Offs
+
+### Benefits
+
+- Small public surface.
+- Easy to understand and document.
+- Builder functions set safe defaults.
+- Avoids public flag conflicts.
+- Backward compatible with existing tools.
+- Lets result metadata stay authoritative per call.
+
+### Costs
+
+- Less flexible than a full capability matrix.
+- Does not represent unusual cases like semantic search with approximate counts.
+- Future tool kinds may need new `kind` values.
+- Best-effort pagination follow-up can fail if the relevant tool result falls out of model context or if the user has multiple active paginated lists and says "show more" ambiguously.
+
+These costs are acceptable for v1. If unusual cases appear later, the library can add carefully scoped extensions such as:
+
+```ts
+capabilities?: {
+  approximateCount?: true;
+}
+```
+
+Do not add this in v1 without a concrete use case.
+
+## Recommended First Slice
+
+1. Extend `DatabaseChatTool` with optional `metadata?: DatabaseChatToolMetadata`.
+2. Add `DatabaseChatToolKind` and `DatabaseChatToolMetadata` exports.
+3. Have typed builders set `metadata.kind` and `metadata.resultContract`.
+4. Treat missing metadata as `kind: "unknown"`.
+5. Add `toolGuidance?: "auto" | "disabled"` to send config.
+6. Automatically append reliability guidance when `toolGuidance !== "disabled"`.
+7. Generate guidance based on the tool kinds present.
+8. Prefer result metadata over tool metadata for a specific call.
+9. Add tests for:
+   - builder metadata defaults;
+   - raw tools treated as unknown;
+   - automatic guidance includes count behavior;
+   - automatic guidance includes paginated follow-up behavior;
+   - automatic guidance includes semantic search count warning;
+   - guidance can be disabled;
+   - result metadata is documented/tested as authoritative.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # DatabaseChat Component
 
-> **Alpha Release** - A Convex component for adding natural language database queries to your app.
+> **Alpha Release** - A Convex component for adding natural language database
+> queries to your app.
 
-DatabaseChat lets users ask questions about your data in plain English. The LLM calls tools you define to query your database and returns helpful, actionable responses.
+DatabaseChat lets users ask questions about your data in plain English. The LLM
+calls tools you define to query your database and returns helpful, actionable
+responses.
 
 ## Table of Contents
 
@@ -25,40 +28,44 @@ DatabaseChat lets users ask questions about your data in plain English. The LLM 
 
 The component provides:
 
-| Feature | Description |
-|---------|-------------|
-| **Conversation storage** | Stores chat history in `conversations` and `messages` tables |
-| **Delta-based streaming** | Efficient O(n) streaming via delta accumulation |
-| **Abort support** | Stop generation mid-stream with proper cleanup |
-| **Tool calling** | LLM can call your Convex queries to fetch data |
-| **React hooks** | `useDatabaseChat`, `useMessagesWithStreaming`, etc. |
-| **Client wrapper** | `defineDatabaseChat()` for type-safe integration |
+| Feature                   | Description                                                  |
+| ------------------------- | ------------------------------------------------------------ |
+| **Conversation storage**  | Stores chat history in `conversations` and `messages` tables |
+| **Delta-based streaming** | Efficient O(n) streaming via delta accumulation              |
+| **Abort support**         | Stop generation mid-stream with proper cleanup               |
+| **Tool calling**          | LLM can call your Convex queries to fetch data               |
+| **React hooks**           | `useDatabaseChat`, `useMessagesWithStreaming`, etc.          |
+| **Client wrapper**        | `defineDatabaseChat()` for type-safe integration             |
 
 **You implement:**
 
-| Your Code | Description |
-|-----------|-------------|
-| **Tool definitions** | What queries the LLM can call |
-| **Query functions** | The actual Convex queries |
-| **Chat integration** | Wire tools to the component |
-| **System prompt** | Instructions for your domain |
-| **UI component** | Chat interface (or use the hooks) |
+| Your Code            | Description                       |
+| -------------------- | --------------------------------- |
+| **Tool definitions** | What queries the LLM can call     |
+| **Query functions**  | The actual Convex queries         |
+| **Chat integration** | Wire tools to the component       |
+| **System prompt**    | Instructions for your domain      |
+| **UI component**     | Chat interface (or use the hooks) |
 
 ### How Delta-Based Streaming Works
 
-Traditional streaming sends the full accumulated content on every update, resulting in O(n²) bandwidth:
+Traditional streaming sends the full accumulated content on every update,
+resulting in O(n²) bandwidth:
+
 - Update 1: "H" (1 byte)
 - Update 2: "He" (2 bytes)
 - Update 3: "Hel" (3 bytes)
 - ...for a 1000 character response, you send ~500,000 bytes total
 
 Delta-based streaming sends only new content, resulting in O(n) bandwidth:
+
 - Delta 1: "H" (1 byte)
 - Delta 2: "e" (1 byte)
 - Delta 3: "l" (1 byte)
 - ...for a 1000 character response, you send ~1000 bytes total
 
-The client accumulates deltas locally and the server cleans them up when the stream finishes.
+The client accumulates deltas locally and the server cleans them up when the
+stream finishes.
 
 ---
 
@@ -188,10 +195,13 @@ export const getStreamDeltas = query({
 export const abortStream = mutation({
   args: { conversationId: v.string(), reason: v.optional(v.string()) },
   handler: async (ctx, args) => {
-    return await ctx.runMutation(components.databaseChat.stream.abortByConversation, {
-      conversationId: args.conversationId as any,
-      reason: args.reason ?? "User cancelled",
-    });
+    return await ctx.runMutation(
+      components.databaseChat.stream.abortByConversation,
+      {
+        conversationId: args.conversationId as any,
+        reason: args.reason ?? "User cancelled",
+      },
+    );
   },
 });
 
@@ -212,25 +222,30 @@ Tools tell the LLM what queries it can call. Each tool needs:
 
 ```typescript
 interface Tool {
-  name: string;           // Unique identifier
-  description: string;    // What the tool does (LLM reads this!)
-  parameters: {           // JSON Schema for arguments
+  name: string; // Unique identifier
+  description: string; // What the tool does (LLM reads this!)
+  parameters: {
+    // JSON Schema for arguments
     type: "object";
-    properties: Record<string, {
-      type: "string" | "number" | "boolean" | "array" | "object";
-      description?: string;
-      enum?: string[];    // For constrained values
-    }>;
+    properties: Record<
+      string,
+      {
+        type: "string" | "number" | "boolean" | "array" | "object";
+        description?: string;
+        enum?: string[]; // For constrained values
+      }
+    >;
     required?: string[];
   };
-  handlerType?: "query" | "mutation" | "action"; // Default: "query"
-  handler: string;        // Function handle string (createFunctionHandle)
+  handlerType?: "query" | "mutation" | "action"; // Raw tools default to "query"
+  handler: string; // Function handle string (createFunctionHandle)
 }
 ```
 
 Note: When passing tools to the component chat action, `handler` should be a
-function handle created via `createFunctionHandle(...)`. Set `handlerType` to
-"action" for tools that run `ctx.vectorSearch`.
+function handle created via `await createFunctionHandle(...)` inside a Convex
+function. Set `handlerType` to `"action"` for raw tools that run
+`ctx.vectorSearch`. `defineSemanticSearchTool` defaults to `"action"`.
 
 ### Standard result contracts and typed builders
 
@@ -274,6 +289,12 @@ using semantic-search result length as a count. Set `toolGuidance: "disabled"`
 or pass a custom string in `defineDatabaseChat` / `chat.send` config to override
 the generated guidance.
 
+Builder defaults:
+
+- `defineCountTool`: exact totals, query handler by default.
+- `definePaginatedListTool`: cursor pages, query handler by default.
+- `defineSemanticSearchTool`: sampled top-K results, action handler by default.
+
 ### Example: E-commerce - Search products
 
 ```typescript
@@ -316,7 +337,8 @@ const searchProductsTool = {
 ```typescript
 const getTasksTool = {
   name: "getTasks",
-  description: "Get tasks with optional filters for status, assignee, or project",
+  description:
+    "Get tasks with optional filters for status, assignee, or project",
   parameters: {
     type: "object",
     properties: {
@@ -379,15 +401,19 @@ const searchArticlesTool = {
 
 ### Tips for tool descriptions
 
-- **Be specific**: "Search products by name, category, or price" is better than "Search products"
-- **List available options**: "Available categories: electronics, clothing, home, sports"
-- **Explain what each parameter does**: The LLM uses descriptions to decide which to use
+- **Be specific**: "Search products by name, category, or price" is better than
+  "Search products"
+- **List available options**: "Available categories: electronics, clothing,
+  home, sports"
+- **Explain what each parameter does**: The LLM uses descriptions to decide
+  which to use
 
 ---
 
 ## Implementing Query Functions
 
-Your query functions do the actual database work. They receive the arguments the LLM provides.
+Your query functions do the actual database work. They receive the arguments the
+LLM provides.
 
 ### Example: E-commerce - Search with filters
 
@@ -412,7 +438,7 @@ export const searchProducts = query({
       price: v.number(),
       inStock: v.boolean(),
       viewUrl: v.string(),
-    })
+    }),
   ),
   handler: async (ctx, args) => {
     const limit = Math.min(args.limit ?? 20, 100);
@@ -494,7 +520,8 @@ export const getOrderStats = query({
 
 ## Creating the Chat Integration
 
-The chat integration wires your tools to the component and handles the LLM interaction.
+The chat integration wires your tools to the component and handles the LLM
+interaction.
 
 ### Full sendMessage implementation
 
@@ -505,7 +532,9 @@ import { action } from "./_generated/server";
 import { components, api } from "./_generated/api";
 
 // Your tools array and system prompt
-const TOOLS = [/* your tools */];
+const TOOLS = [
+  /* your tools */
+];
 const SYSTEM_PROMPT = `/* your prompt */`;
 
 export const sendMessage = action({
@@ -535,7 +564,7 @@ export const sendMessage = action({
       // 2. Get conversation history
       const rawMessages = await ctx.runQuery(
         components.databaseChat.messages.list,
-        { conversationId: args.conversationId as any }
+        { conversationId: args.conversationId as any },
       );
 
       // 3. Build messages array
@@ -545,9 +574,12 @@ export const sendMessage = action({
       ];
 
       // 4. Create stream for delta-based streaming
-      const streamId = await ctx.runMutation(components.databaseChat.stream.create, {
-        conversationId: args.conversationId as any,
-      });
+      const streamId = await ctx.runMutation(
+        components.databaseChat.stream.create,
+        {
+          conversationId: args.conversationId as any,
+        },
+      );
 
       // 5. Call LLM with tools using delta-based streaming
       let deltaCursor = 0;
@@ -557,12 +589,15 @@ export const sendMessage = action({
         TOOLS,
         async (deltaText) => {
           // Send only new text (delta), not accumulated content
-          const success = await ctx.runMutation(components.databaseChat.stream.addDelta, {
-            streamId,
-            start: deltaCursor,
-            end: deltaCursor + 1,
-            parts: [{ type: "text-delta", text: deltaText }],
-          });
+          const success = await ctx.runMutation(
+            components.databaseChat.stream.addDelta,
+            {
+              streamId,
+              start: deltaCursor,
+              end: deltaCursor + 1,
+              parts: [{ type: "text-delta", text: deltaText }],
+            },
+          );
           deltaCursor++;
           // If addDelta returns false, stream was aborted
           if (!success) {
@@ -571,11 +606,13 @@ export const sendMessage = action({
         },
         async (toolName, toolArgs) => {
           return await executeToolCall(ctx, toolName, toolArgs);
-        }
+        },
       );
 
       // 6. Finish streaming (cleans up deltas)
-      await ctx.runMutation(components.databaseChat.stream.finish, { streamId });
+      await ctx.runMutation(components.databaseChat.stream.finish, {
+        streamId,
+      });
 
       // 7. Save assistant response
       await ctx.runMutation(components.databaseChat.messages.add, {
@@ -600,7 +637,7 @@ export const sendMessage = action({
 async function executeToolCall(
   ctx: any,
   toolName: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
 ): Promise<unknown> {
   switch (toolName) {
     case "searchProducts":
@@ -622,7 +659,10 @@ async function callLLMWithTools(
   messages: Array<{ role: string; content: string }>,
   tools: any[],
   onDelta: (deltaText: string) => Promise<void>, // Note: receives delta, not accumulated content
-  executeTool: (name: string, args: Record<string, unknown>) => Promise<unknown>
+  executeTool: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => Promise<unknown>,
 ): Promise<{ content: string }> {
   const formattedTools = tools.map((t) => ({
     type: "function" as const,
@@ -644,7 +684,7 @@ async function callLLMWithTools(
       apiKey,
       currentMessages,
       formattedTools,
-      onDelta
+      onDelta,
     );
 
     // If no tool calls, we're done
@@ -812,7 +852,7 @@ function useDeltaStreaming(conversationId: string | null) {
   // Subscribe to stream state
   const streamState = useQuery(
     api.chat.getStreamState,
-    conversationId ? { conversationId } : "skip"
+    conversationId ? { conversationId } : "skip",
   );
 
   const streamId = streamState?.streamId ?? null;
@@ -831,14 +871,16 @@ function useDeltaStreaming(conversationId: string | null) {
   // Fetch deltas from cursor
   const deltas = useQuery(
     api.chat.getStreamDeltas,
-    streamId && status === "streaming" ? { streamId, cursor } : "skip"
+    streamId && status === "streaming" ? { streamId, cursor } : "skip",
   );
 
   // Accumulate new deltas
   useEffect(() => {
     if (!deltas || deltas.length === 0) return;
 
-    const newDeltas = deltas.filter(d => d.start >= lastProcessedEndRef.current);
+    const newDeltas = deltas.filter(
+      (d) => d.start >= lastProcessedEndRef.current,
+    );
     if (newDeltas.length === 0) return;
 
     let maxEnd = lastProcessedEndRef.current;
@@ -854,14 +896,15 @@ function useDeltaStreaming(conversationId: string | null) {
     }
 
     if (newText) {
-      setAccumulatedContent(prev => prev + newText);
+      setAccumulatedContent((prev) => prev + newText);
     }
     lastProcessedEndRef.current = maxEnd;
     if (maxEnd > cursor) setCursor(maxEnd);
   }, [deltas, cursor]);
 
   return {
-    content: status === "streaming" && accumulatedContent ? accumulatedContent : null,
+    content:
+      status === "streaming" && accumulatedContent ? accumulatedContent : null,
     isStreaming: status === "streaming",
   };
 }
@@ -875,14 +918,15 @@ export function ChatWidget() {
   const createConversation = useMutation(api.chat.createConversation);
   const sendMessage = useAction(api.chat.sendMessage);
   const abortStream = useMutation(api.chat.abortStream);
-  
+
   const messages = useQuery(
     api.chat.getMessages,
-    conversationId ? { conversationId } : "skip"
+    conversationId ? { conversationId } : "skip",
   );
-  
+
   // Use delta-based streaming
-  const { content: streamingContent, isStreaming } = useDeltaStreaming(conversationId);
+  const { content: streamingContent, isStreaming } =
+    useDeltaStreaming(conversationId);
 
   // Create conversation on open
   useEffect(() => {
@@ -909,11 +953,7 @@ export function ChatWidget() {
   };
 
   if (!isOpen) {
-    return (
-      <button onClick={() => setIsOpen(true)}>
-        Open Chat
-      </button>
-    );
+    return <button onClick={() => setIsOpen(true)}>Open Chat</button>;
   }
 
   return (
@@ -925,7 +965,7 @@ export function ChatWidget() {
           <MarkdownContent content={msg.content} />
         </div>
       ))}
-      
+
       {/* Streaming */}
       {streamingContent && (
         <div>
@@ -955,7 +995,8 @@ export function ChatWidget() {
 
 ### Text smoothing with `useSmoothText`
 
-The `useSmoothText` hook creates a typewriter effect for streaming text, making it feel more natural instead of jumping in chunks:
+The `useSmoothText` hook creates a typewriter effect for streaming text, making
+it feel more natural instead of jumping in chunks:
 
 ```tsx
 import { useSmoothText, SmoothText } from "@dayhaysoos/convex-database-chat";
@@ -968,24 +1009,22 @@ function StreamingMessage({ text, isStreaming }) {
     // Optional: customize speed (default: 200 chars/sec)
     initialCharsPerSecond: 200,
   });
-  
+
   return <div>{visibleText}</div>;
 }
 
 // Or use the component directly
 function Message({ text, isStreaming }) {
-  return (
-    <SmoothText 
-      text={text} 
-      startStreaming={isStreaming}
-    />
-  );
+  return <SmoothText text={text} startStreaming={isStreaming} />;
 }
 ```
 
 **Options:**
-- `startStreaming` - Set to `true` for streaming messages, `false` for completed messages (shows immediately)
-- `initialCharsPerSecond` - Starting speed, adapts over time to match text arrival rate
+
+- `startStreaming` - Set to `true` for streaming messages, `false` for completed
+  messages (shows immediately)
+- `initialCharsPerSecond` - Starting speed, adapts over time to match text
+  arrival rate
 - `minDelayMs` / `maxDelayMs` - Bounds for character delay
 
 ### Rendering markdown links
@@ -1052,10 +1091,14 @@ export const semanticSearchCandidates = action({
       // model: "your-embedding-model",
     });
 
-    const results = await ctx.vectorSearch("applications", "by_resume_embedding", {
-      vector: embedding,
-      limit: args.limit ?? 20,
-    });
+    const results = await ctx.vectorSearch(
+      "applications",
+      "by_resume_embedding",
+      {
+        vector: embedding,
+        limit: args.limit ?? 20,
+      },
+    );
 
     const docs = await ctx.runQuery(internal.semanticSearch.fetchByIds, {
       ids: results.map((r) => r._id),
@@ -1071,10 +1114,12 @@ export const semanticSearchCandidates = action({
 ```
 
 **Notes:**
+
 - Vector search is only available in actions.
 - Vector index dimensions must match the embedding model you choose.
 - Use `fields` to avoid returning large vector fields like embeddings.
-- Set `fields: []` to include no document fields (only `_id` and optional `_score`).
+- Set `fields: []` to include no document fields (only `_id` and optional
+  `_score`).
 
 You can also define a tool entry with the helper:
 
@@ -1112,10 +1157,13 @@ Format as markdown: [Item Name](viewUrl)
 ```
 
 **Before (not actionable):**
+
 > "Found 2 products under $50"
 
 **After (actionable):**
+
 > "Found 2 products under $50:
+>
 > - [Wireless Mouse](/products/abc123) - $29.99
 > - [USB Cable](/products/def456) - $12.99"
 
@@ -1123,8 +1171,8 @@ Format as markdown: [Item Name](viewUrl)
 
 ## Security & Multi-tenant Access
 
-This component is auth-agnostic. You must supply `externalId` from your own
-auth system and never accept it directly from untrusted clients.
+This component is auth-agnostic. You must supply `externalId` from your own auth
+system and never accept it directly from untrusted clients.
 
 Use the scoped endpoints below to enforce ownership checks server-side. These
 throw `Not found` if the conversation or stream is missing or not owned by the
@@ -1177,47 +1225,47 @@ sees them.
 
 ### Component Functions
 
-| Function | Type | Description |
-|----------|------|-------------|
-| `conversations.create` | Mutation | Create a new conversation |
-| `conversations.get` | Query | Get conversation by ID |
-| `conversations.getForExternalId` | Query | Get conversation by ID scoped to externalId |
-| `conversations.list` | Query | List conversations by externalId |
-| `messages.add` | Mutation | Add a message |
-| `messages.list` | Query | List messages in conversation |
-| `messages.listForExternalId` | Query | List messages scoped to externalId |
-| `messages.getLatestForExternalId` | Query | Get latest message scoped to externalId |
-| `stream.create` | Mutation | Create a new stream for delta-based streaming |
-| `stream.addDelta` | Mutation | Add a delta (batch of parts) to a stream |
-| `stream.finish` | Mutation | Mark stream as finished, clean up deltas |
-| `stream.abort` | Mutation | Abort a stream by stream ID |
-| `stream.abortByConversation` | Mutation | Abort a stream by conversation ID |
-| `stream.abortForExternalId` | Mutation | Abort a stream by conversation ID scoped to externalId |
-| `stream.getStream` | Query | Get current stream state for a conversation |
-| `stream.listDeltas` | Query | Get deltas from a cursor position |
-| `stream.getStreamForExternalId` | Query | Get current stream state scoped to externalId |
-| `stream.listDeltasForExternalId` | Query | Get deltas scoped to externalId |
-| `chat.send` | Action | Send a message via OpenRouter |
-| `chat.sendForExternalId` | Action | Send a message scoped to externalId |
+| Function                          | Type     | Description                                            |
+| --------------------------------- | -------- | ------------------------------------------------------ |
+| `conversations.create`            | Mutation | Create a new conversation                              |
+| `conversations.get`               | Query    | Get conversation by ID                                 |
+| `conversations.getForExternalId`  | Query    | Get conversation by ID scoped to externalId            |
+| `conversations.list`              | Query    | List conversations by externalId                       |
+| `messages.add`                    | Mutation | Add a message                                          |
+| `messages.list`                   | Query    | List messages in conversation                          |
+| `messages.listForExternalId`      | Query    | List messages scoped to externalId                     |
+| `messages.getLatestForExternalId` | Query    | Get latest message scoped to externalId                |
+| `stream.create`                   | Mutation | Create a new stream for delta-based streaming          |
+| `stream.addDelta`                 | Mutation | Add a delta (batch of parts) to a stream               |
+| `stream.finish`                   | Mutation | Mark stream as finished, clean up deltas               |
+| `stream.abort`                    | Mutation | Abort a stream by stream ID                            |
+| `stream.abortByConversation`      | Mutation | Abort a stream by conversation ID                      |
+| `stream.abortForExternalId`       | Mutation | Abort a stream by conversation ID scoped to externalId |
+| `stream.getStream`                | Query    | Get current stream state for a conversation            |
+| `stream.listDeltas`               | Query    | Get deltas from a cursor position                      |
+| `stream.getStreamForExternalId`   | Query    | Get current stream state scoped to externalId          |
+| `stream.listDeltasForExternalId`  | Query    | Get deltas scoped to externalId                        |
+| `chat.send`                       | Action   | Send a message via OpenRouter                          |
+| `chat.sendForExternalId`          | Action   | Send a message scoped to externalId                    |
 
 ### React Hooks & Components
 
-| Export | Type | Description |
-|--------|------|-------------|
-| `useDatabaseChat` | Hook | Send messages, track loading/streaming state, abort |
-| `useConversations` | Hook | List/create conversations |
-| `useStreamingContent` | Hook | Subscribe to streaming updates with delta accumulation |
-| `useMessagesWithStreaming` | Hook | Messages + current streaming merged |
-| `useSmoothText` | Hook | Typewriter effect for streaming text |
-| `SmoothText` | Component | Renders text with smooth typewriter effect |
+| Export                     | Type      | Description                                            |
+| -------------------------- | --------- | ------------------------------------------------------ |
+| `useDatabaseChat`          | Hook      | Send messages, track loading/streaming state, abort    |
+| `useConversations`         | Hook      | List/create conversations                              |
+| `useStreamingContent`      | Hook      | Subscribe to streaming updates with delta accumulation |
+| `useMessagesWithStreaming` | Hook      | Messages + current streaming merged                    |
+| `useSmoothText`            | Hook      | Typewriter effect for streaming text                   |
+| `SmoothText`               | Component | Renders text with smooth typewriter effect             |
 
 ### Stream States
 
-| Status | Description |
-|--------|-------------|
-| `streaming` | Stream is active, deltas being written |
-| `finished` | Stream completed successfully |
-| `aborted` | Stream was cancelled (user abort, error, or timeout) |
+| Status      | Description                                          |
+| ----------- | ---------------------------------------------------- |
+| `streaming` | Stream is active, deltas being written               |
+| `finished`  | Stream completed successfully                        |
+| `aborted`   | Stream was cancelled (user abort, error, or timeout) |
 
 ---
 
@@ -1225,7 +1273,8 @@ sees them.
 
 This repo hosts two Railway services, each with its own config file:
 
-- Example app: Root Directory `/example`, Railway Config File `/example/railway.toml`
+- Example app: Root Directory `/example`, Railway Config File
+  `/example/railway.toml`
 - Docs site: Root Directory `/docs`, Railway Config File `/docs/railway.toml`
 
 Note: Railway does not automatically follow the Root Directory when selecting a

--- a/README.md
+++ b/README.md
@@ -232,6 +232,48 @@ Note: When passing tools to the component chat action, `handler` should be a
 function handle created via `createFunctionHandle(...)`. Set `handlerType` to
 "action" for tools that run `ctx.vectorSearch`.
 
+### Standard result contracts and typed builders
+
+For count, deterministic list, and semantic-search tools that return the
+standard `{ data, meta }` result envelope, use the typed builders from the
+backend-safe tools entrypoint:
+
+```typescript
+import {
+  definePaginatedListTool,
+  enumFilter,
+  injectedString,
+} from "@dayhaysoos/convex-database-chat/tools";
+import type { DatabaseChatToolResult } from "@dayhaysoos/convex-database-chat/resultContract";
+
+type ProductRow = {
+  id: string;
+  name: string;
+  viewUrl: string;
+};
+
+const listProductsTool = definePaginatedListTool<ProductRow>({
+  name: "listProducts",
+  description: "List products matching deterministic filters.",
+  handler: "listProductsHandler",
+  filters: {
+    category: enumFilter({
+      values: ["electronics", "clothing", "home", "sports"] as const,
+    }),
+  },
+  injectedArgs: {
+    tenantId: injectedString(),
+  },
+});
+```
+
+Builders attach `tool.metadata.kind` and `metadata.resultContract = "standard"`.
+DatabaseChat uses that metadata to inject generic guidance by default, including
+using `meta.count` for exact totals, treating cursor results as pages, and not
+using semantic-search result length as a count. Set `toolGuidance: "disabled"`
+or pass a custom string in `defineDatabaseChat` / `chat.send` config to override
+the generated guidance.
+
 ### Example: E-commerce - Search products
 
 ```typescript

--- a/convex/component/_generated/component.ts
+++ b/convex/component/_generated/component.ts
@@ -30,11 +30,24 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         {
           config: {
             apiKey: string;
+            maxMessagesForLLM?: number;
             model?: string;
             systemPrompt?: string;
+            toolContext?: any;
+            toolGuidance?: string;
             tools?: Array<{
               description: string;
               handler: string;
+              handlerType?: "query" | "mutation" | "action";
+              metadata?: {
+                kind:
+                  | "count"
+                  | "paginated_list"
+                  | "semantic_search"
+                  | "detail"
+                  | "unknown";
+                resultContract?: "standard";
+              };
               name: string;
               parameters: {
                 properties: any;

--- a/convex/component/_generated/component.ts
+++ b/convex/component/_generated/component.ts
@@ -50,6 +50,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
               };
               name: string;
               parameters: {
+                additionalProperties?: boolean;
                 properties: any;
                 required?: Array<string>;
                 type: "object";

--- a/convex/component/chat.ts
+++ b/convex/component/chat.ts
@@ -9,6 +9,10 @@ import {
   validateToolArgs,
 } from "./tools";
 import type { DatabaseChatTool } from "./tools";
+import {
+  buildSystemPromptWithTools,
+  type ToolGuidanceOption,
+} from "./toolGuidance";
 import { DeltaStreamer } from "./deltaStreamer";
 import { executeToolWithContext } from "./toolExecution";
 
@@ -16,6 +20,7 @@ const sendConfigValidator = v.object({
   apiKey: v.string(),
   model: v.optional(v.string()),
   systemPrompt: v.optional(v.string()),
+  toolGuidance: v.optional(v.string()),
   // Tools the LLM can call
   tools: v.optional(v.array(databaseChatToolValidator)),
   // Max messages to include in LLM context (default: 50)
@@ -93,12 +98,8 @@ async function sendInternal(
       apiKey: string;
       model?: string;
       systemPrompt?: string;
-      tools?: Array<{
-        name: string;
-        description: string;
-        parameters: unknown;
-        handler: string;
-      }>;
+      toolGuidance?: ToolGuidanceOption;
+      tools?: DatabaseChatTool[];
       maxMessagesForLLM?: number;
       toolContext?: Record<string, unknown>;
     };
@@ -139,9 +140,10 @@ async function sendInternal(
     await streamer.getStreamId();
 
     // 4. Build messages for OpenRouter
-    const systemPrompt = buildSystemPrompt(
+    const systemPrompt = buildSystemPromptWithTools(
       config.systemPrompt ?? DEFAULT_SYSTEM_PROMPT,
-      tools
+      tools,
+      { toolGuidance: config.toolGuidance }
     );
     const openRouterMessages = buildMessages(messages, systemPrompt);
 
@@ -306,29 +308,6 @@ const DEFAULT_SYSTEM_PROMPT = `You are a helpful assistant that can search and q
 When users ask questions, use the available tools to find relevant information.
 If you don't have access to a tool that can answer the question, say so.
 Always explain what you found in a clear, helpful way.`;
-
-/**
- * Build system prompt with tool descriptions
- */
-function buildSystemPrompt(
-  basePrompt: string,
-  tools: DatabaseChatTool[]
-): string {
-  if (tools.length === 0) {
-    return basePrompt;
-  }
-
-  const toolDescriptions = tools
-    .map((t) => `- ${t.name}: ${t.description}`)
-    .join("\n");
-
-  return `${basePrompt}
-
-You have access to the following tools to query the database:
-${toolDescriptions}
-
-Use these tools to answer questions about the data. You can call multiple tools if needed.`;
-}
 
 /**
  * Build messages array for OpenRouter API (without tools)

--- a/convex/component/client.test.ts
+++ b/convex/component/client.test.ts
@@ -4,6 +4,7 @@ import { convexTest } from "convex-test";
 import schema from "./schema";
 import { api } from "./_generated/api";
 import { DatabaseChatClient, defineDatabaseChat } from "./client";
+import { definePaginatedListTool } from "./tools";
 
 const modules = import.meta.glob("./**/*.ts");
 
@@ -25,6 +26,47 @@ describe("DatabaseChatClient", () => {
     it("should work with default config", () => {
       const client = defineDatabaseChat(api);
       expect(client).toBeInstanceOf(DatabaseChatClient);
+    });
+
+    it("builds system prompts with automatic tool reliability guidance by default", () => {
+      const listTool = definePaginatedListTool({
+        name: "listRecords",
+        description: "List records.",
+        handler: "handler_string",
+      });
+
+      const automatic = defineDatabaseChat(api, {
+        systemPrompt: "Base prompt.",
+        tools: [listTool],
+      });
+
+      expect(automatic.getSystemPromptWithTools()).toContain(
+        "Tool result reliability:"
+      );
+      expect(automatic.getSystemPromptWithTools()).toContain(
+        "meta.pagination.nextCursor"
+      );
+
+      const disabled = defineDatabaseChat(api, {
+        systemPrompt: "Base prompt.",
+        tools: [listTool],
+        toolGuidance: "disabled",
+      });
+      expect(disabled.getSystemPromptWithTools()).not.toContain(
+        "Tool result reliability:"
+      );
+
+      const custom = defineDatabaseChat(api, {
+        systemPrompt: "Base prompt.",
+        tools: [listTool],
+        toolGuidance: "Always mention exact scope labels.",
+      });
+      expect(custom.getSystemPromptWithTools()).toContain(
+        "Always mention exact scope labels."
+      );
+      expect(custom.getSystemPromptWithTools()).not.toContain(
+        "Tool result reliability:"
+      );
     });
   });
 

--- a/convex/component/client.ts
+++ b/convex/component/client.ts
@@ -83,6 +83,10 @@ import type { DatabaseChatTool, AutoToolsConfig } from "./tools";
 import type { TableInfo, SchemaToolHandlers } from "./schemaTools";
 import { generateToolsFromSchema } from "./schemaTools";
 import { formatToolsForLLM, findTool, validateToolArgs } from "./tools";
+import {
+  buildSystemPromptWithTools,
+  type ToolGuidanceOption,
+} from "./toolGuidance";
 
 // Type for the component API (what apps get from components.databaseChat)
 type ComponentApi = typeof api;
@@ -97,6 +101,8 @@ export interface DatabaseChatConfig {
   model?: string;
   /** Default system prompt */
   systemPrompt?: string;
+  /** Reliability guidance for standard tool result contracts (default: "auto"). */
+  toolGuidance?: ToolGuidanceOption;
   /**
    * Explicit tool definitions.
    * Use this for precise control over what queries the LLM can run.
@@ -133,6 +139,8 @@ export interface SendMessageOptions {
   model?: string;
   /** Override system prompt for this message */
   systemPrompt?: string;
+  /** Override tool reliability guidance for this message */
+  toolGuidance?: ToolGuidanceOption;
   /** Server-side context merged into tool args (not exposed to LLM) */
   toolContext?: Record<string, unknown>;
 }
@@ -349,6 +357,7 @@ export class DatabaseChatClient {
         apiKey: options.apiKey,
         model: options.model ?? this.config.model,
         systemPrompt: options.systemPrompt ?? this.config.systemPrompt,
+        toolGuidance: options.toolGuidance ?? this.config.toolGuidance,
         tools: this.tools.length > 0 ? this.tools : undefined,
         maxMessagesForLLM: this.config.maxMessagesForLLM ?? 50,
         toolContext: options.toolContext,
@@ -412,7 +421,11 @@ export class DatabaseChatClient {
   async getMessagesForLLM(
     ctx: QueryCtx,
     conversationId: string,
-    options?: { systemPrompt?: string; includeTools?: boolean }
+    options?: {
+      systemPrompt?: string;
+      includeTools?: boolean;
+      toolGuidance?: ToolGuidanceOption;
+    }
   ): Promise<{
     messages: Array<{ role: string; content: string }>;
     tools?: ReturnType<typeof formatToolsForLLM>;
@@ -425,17 +438,13 @@ export class DatabaseChatClient {
 
     const formatted: Array<{ role: string; content: string }> = [];
 
-    // Build system prompt with tool descriptions if tools are configured
-    let systemPrompt = options?.systemPrompt ?? this.config.systemPrompt ?? "";
-
-    if (this.hasTools() && options?.includeTools !== false) {
-      const toolDescriptions = this.tools
-        .map((t) => `- ${t.name}: ${t.description}`)
-        .join("\n");
-      systemPrompt += systemPrompt
-        ? `\n\nYou have access to the following tools to query the database:\n${toolDescriptions}`
-        : `You have access to the following tools to query the database:\n${toolDescriptions}`;
-    }
+    const basePrompt = options?.systemPrompt ?? this.config.systemPrompt ?? "";
+    const systemPrompt =
+      this.hasTools() && options?.includeTools !== false
+        ? buildSystemPromptWithTools(basePrompt, this.tools, {
+            toolGuidance: options?.toolGuidance ?? this.config.toolGuidance,
+          })
+        : basePrompt;
 
     if (systemPrompt) {
       formatted.push({ role: "system", content: systemPrompt });
@@ -473,20 +482,19 @@ export class DatabaseChatClient {
   /**
    * Build the system prompt with optional tool descriptions.
    */
-  getSystemPromptWithTools(basePrompt?: string): string {
+  getSystemPromptWithTools(
+    basePrompt?: string,
+    toolGuidance?: ToolGuidanceOption
+  ): string {
     const prompt = basePrompt ?? this.config.systemPrompt ?? "";
 
     if (!this.hasTools()) {
       return prompt;
     }
 
-    const toolDescriptions = this.tools
-      .map((t) => `- ${t.name}: ${t.description}`)
-      .join("\n");
-
-    return prompt
-      ? `${prompt}\n\nYou have access to the following tools to query the database:\n${toolDescriptions}`
-      : `You have access to the following tools to query the database:\n${toolDescriptions}`;
+    return buildSystemPromptWithTools(prompt, this.tools, {
+      toolGuidance: toolGuidance ?? this.config.toolGuidance,
+    });
   }
 }
 

--- a/convex/component/resultContract.test.ts
+++ b/convex/component/resultContract.test.ts
@@ -1,0 +1,169 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import {
+  isDatabaseChatToolResult,
+  validateToolResultContract,
+  type DatabaseChatToolResult,
+} from "./resultContract";
+
+describe("result contract", () => {
+  it("accepts a count-only result with an exact count and no rows", () => {
+    const result: DatabaseChatToolResult = {
+      data: [],
+      meta: {
+        scope: { type: "workspace", id: "workspace_123" },
+        appliedFilters: { status: "active" },
+        count: 200,
+        returned: 0,
+        exhaustive: true,
+        truncated: false,
+        sampled: false,
+      },
+    };
+
+    expect(validateToolResultContract(result)).toEqual([]);
+    expect(isDatabaseChatToolResult(result)).toBe(true);
+  });
+
+  it("rejects a result whose returned count does not match data length", () => {
+    const errors = validateToolResultContract({
+      data: [{ id: "record_1" }],
+      meta: {
+        scope: { type: "workspace" },
+        returned: 2,
+        exhaustive: true,
+        truncated: false,
+        sampled: false,
+      },
+    });
+
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        code: "returned_mismatch",
+        path: "$.meta.returned",
+      })
+    );
+    expect(
+      isDatabaseChatToolResult({
+        data: [{ id: "record_1" }],
+        meta: {
+          scope: { type: "workspace" },
+          returned: 2,
+          exhaustive: true,
+          truncated: false,
+          sampled: false,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a deterministic first page with an exact count and next cursor", () => {
+    const result: DatabaseChatToolResult<{ id: string }> = {
+      data: Array.from({ length: 20 }, (_, index) => ({
+        id: `record_${index + 1}`,
+      })),
+      meta: {
+        scope: { type: "workspace", label: "Example Workspace" },
+        appliedFilters: { status: "active" },
+        count: 200,
+        returned: 20,
+        exhaustive: false,
+        truncated: true,
+        truncationReason: "row_limit",
+        sampled: false,
+        pagination: {
+          cursor: null,
+          hasMore: true,
+          nextCursor: "cursor_2",
+          pageSize: 20,
+        },
+      },
+    };
+
+    expect(validateToolResultContract(result)).toEqual([]);
+  });
+
+  it("accepts semantic top-K results as sampled results without count", () => {
+    const result: DatabaseChatToolResult<{ id: string; score: number }> = {
+      data: [{ id: "record_1", score: 0.92 }],
+      meta: {
+        scope: { type: "workspace" },
+        appliedFilters: { query: "database reliability" },
+        returned: 1,
+        exhaustive: false,
+        truncated: true,
+        truncationReason: "semantic_top_k_limit",
+        sampled: true,
+        sampleMethod: "semantic_top_k",
+      },
+    };
+
+    expect(validateToolResultContract(result)).toEqual([]);
+  });
+
+  it("returns all contract errors for contradictory metadata", () => {
+    const errors = validateToolResultContract({
+      data: [{ id: "record_1" }],
+      meta: {
+        scope: { type: "workspace" },
+        count: 10,
+        returned: 1,
+        exhaustive: true,
+        truncated: true,
+        sampled: true,
+        pagination: { hasMore: true },
+      },
+    });
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "sampled_exhaustive_conflict" }),
+        expect.objectContaining({ code: "sampled_count_conflict" }),
+        expect.objectContaining({ code: "pagination_sampled_conflict" }),
+        expect.objectContaining({ code: "pagination_cursor_required" }),
+        expect.objectContaining({ code: "pagination_exhaustive_conflict" }),
+        expect.objectContaining({ code: "exhaustive_truncated_conflict" }),
+        expect.objectContaining({ code: "missing_truncation_reason" }),
+        expect.objectContaining({ code: "missing_sample_method" }),
+      ])
+    );
+  });
+
+  it("rejects invalid optional metadata shapes without validating app semantics", () => {
+    const errors = validateToolResultContract({
+      data: [],
+      meta: {
+        scope: { type: "", id: "", label: "" },
+        appliedFilters: [],
+        returned: 0,
+        count: -1,
+        exhaustive: false,
+        truncated: false,
+        truncationReason: "",
+        sampled: false,
+        sampleMethod: "",
+        pagination: {
+          cursor: 123,
+          hasMore: false,
+          nextCursor: "",
+          pageSize: 1.5,
+        },
+      },
+    });
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "invalid_scope" }),
+        expect.objectContaining({ code: "invalid_scope_id" }),
+        expect.objectContaining({ code: "invalid_scope_label" }),
+        expect.objectContaining({ code: "invalid_applied_filters" }),
+        expect.objectContaining({ code: "invalid_count" }),
+        expect.objectContaining({ code: "invalid_truncation_reason" }),
+        expect.objectContaining({ code: "invalid_sample_method" }),
+        expect.objectContaining({ code: "invalid_pagination_cursor" }),
+        expect.objectContaining({ code: "invalid_pagination_next_cursor" }),
+        expect.objectContaining({ code: "invalid_pagination_page_size" }),
+      ])
+    );
+  });
+});

--- a/convex/component/resultContract.ts
+++ b/convex/component/resultContract.ts
@@ -1,0 +1,342 @@
+export type DatabaseChatScope = {
+  type: string;
+  id?: string;
+  label?: string;
+};
+
+export type DatabaseChatResultMeta = {
+  scope: DatabaseChatScope;
+  appliedFilters?: Record<string, unknown>;
+  count?: number;
+  returned: number;
+  exhaustive: boolean;
+  truncated: boolean;
+  truncationReason?: string;
+  sampled: boolean;
+  sampleMethod?: string;
+  pagination?: {
+    cursor?: string | null;
+    hasMore: boolean;
+    nextCursor?: string | null;
+    pageSize?: number;
+  };
+};
+
+export type DatabaseChatToolResult<Row = unknown> = {
+  data: Row[];
+  meta: DatabaseChatResultMeta;
+};
+
+export type DatabaseChatResultValidationError = {
+  code: string;
+  path: string;
+  message: string;
+};
+
+export function validateToolResultContract(
+  result: unknown
+): DatabaseChatResultValidationError[] {
+  const errors: DatabaseChatResultValidationError[] = [];
+  const addError = (
+    code: string,
+    path: string,
+    message: string
+  ): void => {
+    errors.push({ code, path, message });
+  };
+
+  if (!isRecord(result)) {
+    return [
+      {
+        code: "invalid_result",
+        path: "$",
+        message: "Result must be an object.",
+      },
+    ];
+  }
+
+  if (!Array.isArray(result.data)) {
+    addError("invalid_data", "$.data", "Result data must be an array.");
+  }
+
+  if (!isRecord(result.meta)) {
+    addError("invalid_meta", "$.meta", "Result meta must be an object.");
+    return errors;
+  }
+
+  const meta = result.meta;
+  const dataLength = Array.isArray(result.data) ? result.data.length : 0;
+
+  if (!isNonNegativeSafeInteger(meta.returned)) {
+    addError(
+      "invalid_returned",
+      "$.meta.returned",
+      "meta.returned must be a non-negative safe integer."
+    );
+  } else if (meta.returned !== dataLength) {
+    addError(
+      "returned_mismatch",
+      "$.meta.returned",
+      "meta.returned must equal data.length."
+    );
+  }
+
+  if (!isRecord(meta.scope)) {
+    addError(
+      "invalid_scope",
+      "$.meta.scope",
+      "meta.scope must include a non-empty string type."
+    );
+  } else {
+    if (!isNonEmptyString(meta.scope.type)) {
+      addError(
+        "invalid_scope",
+        "$.meta.scope.type",
+        "meta.scope.type must be a non-empty string."
+      );
+    }
+    if (meta.scope.id !== undefined && !isNonEmptyString(meta.scope.id)) {
+      addError(
+        "invalid_scope_id",
+        "$.meta.scope.id",
+        "meta.scope.id must be a non-empty string when present."
+      );
+    }
+    if (
+      meta.scope.label !== undefined &&
+      !isNonEmptyString(meta.scope.label)
+    ) {
+      addError(
+        "invalid_scope_label",
+        "$.meta.scope.label",
+        "meta.scope.label must be a non-empty string when present."
+      );
+    }
+  }
+
+  if (meta.count !== undefined && !isNonNegativeSafeInteger(meta.count)) {
+    addError(
+      "invalid_count",
+      "$.meta.count",
+      "meta.count must be a non-negative safe integer when present."
+    );
+  }
+
+  for (const field of ["exhaustive", "truncated", "sampled"] as const) {
+    if (typeof meta[field] !== "boolean") {
+      addError(
+        `invalid_${field}`,
+        `$.meta.${field}`,
+        `meta.${field} must be a boolean.`
+      );
+    }
+  }
+
+  if (meta.appliedFilters !== undefined && !isRecord(meta.appliedFilters)) {
+    addError(
+      "invalid_applied_filters",
+      "$.meta.appliedFilters",
+      "meta.appliedFilters must be an object when present."
+    );
+  }
+
+  if (meta.sampled === true && meta.exhaustive === true) {
+    addError(
+      "sampled_exhaustive_conflict",
+      "$.meta",
+      "Sampled results cannot also be exhaustive."
+    );
+  }
+
+  if (meta.sampled === true && meta.count !== undefined) {
+    addError(
+      "sampled_count_conflict",
+      "$.meta.count",
+      "Sampled results must not include meta.count in v1."
+    );
+  }
+
+  if (meta.exhaustive === true && meta.truncated === true) {
+    addError(
+      "exhaustive_truncated_conflict",
+      "$.meta",
+      "Exhaustive results cannot also be truncated."
+    );
+  }
+
+  validateReasonField({
+    errors,
+    fieldName: "truncationReason",
+    path: "$.meta.truncationReason",
+    value: meta.truncationReason,
+    required: meta.truncated === true,
+    missingCode: "missing_truncation_reason",
+    invalidCode: "invalid_truncation_reason",
+    missingMessage:
+      "meta.truncationReason is required when meta.truncated is true.",
+    invalidMessage:
+      "meta.truncationReason must be a non-empty string when present.",
+  });
+
+  validateReasonField({
+    errors,
+    fieldName: "sampleMethod",
+    path: "$.meta.sampleMethod",
+    value: meta.sampleMethod,
+    required: meta.sampled === true,
+    missingCode: "missing_sample_method",
+    invalidCode: "invalid_sample_method",
+    missingMessage: "meta.sampleMethod is required when meta.sampled is true.",
+    invalidMessage: "meta.sampleMethod must be a non-empty string when present.",
+  });
+
+  if (meta.pagination !== undefined) {
+    validatePagination(meta.pagination, meta, errors);
+  }
+
+  return errors;
+}
+
+export function isDatabaseChatToolResult(
+  result: unknown
+): result is DatabaseChatToolResult {
+  return validateToolResultContract(result).length === 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0
+  );
+}
+
+function validateReasonField(options: {
+  errors: DatabaseChatResultValidationError[];
+  fieldName: string;
+  path: string;
+  value: unknown;
+  required: boolean;
+  missingCode: string;
+  invalidCode: string;
+  missingMessage: string;
+  invalidMessage: string;
+}) {
+  const {
+    errors,
+    path,
+    value,
+    required,
+    missingCode,
+    invalidCode,
+    missingMessage,
+    invalidMessage,
+  } = options;
+
+  if (required && value === undefined) {
+    errors.push({ code: missingCode, path, message: missingMessage });
+    return;
+  }
+
+  if (value !== undefined && !isNonEmptyString(value)) {
+    errors.push({ code: invalidCode, path, message: invalidMessage });
+  }
+}
+
+function validatePagination(
+  pagination: unknown,
+  meta: Record<string, unknown>,
+  errors: DatabaseChatResultValidationError[]
+) {
+  const addError = (
+    code: string,
+    path: string,
+    message: string
+  ): void => {
+    errors.push({ code, path, message });
+  };
+
+  if (!isRecord(pagination)) {
+    addError(
+      "invalid_pagination",
+      "$.meta.pagination",
+      "meta.pagination must be an object when present."
+    );
+    return;
+  }
+
+  if (meta.sampled === true) {
+    addError(
+      "pagination_sampled_conflict",
+      "$.meta.pagination",
+      "Pagination is only valid for non-sampled results."
+    );
+  }
+
+  if (typeof pagination.hasMore !== "boolean") {
+    addError(
+      "invalid_pagination_has_more",
+      "$.meta.pagination.hasMore",
+      "meta.pagination.hasMore must be a boolean."
+    );
+  }
+
+  if (
+    pagination.cursor !== undefined &&
+    pagination.cursor !== null &&
+    typeof pagination.cursor !== "string"
+  ) {
+    addError(
+      "invalid_pagination_cursor",
+      "$.meta.pagination.cursor",
+      "meta.pagination.cursor must be a string or null when present."
+    );
+  }
+
+  if (pagination.hasMore === true) {
+    if (!isNonEmptyString(pagination.nextCursor)) {
+      addError(
+        "pagination_cursor_required",
+        "$.meta.pagination.nextCursor",
+        "meta.pagination.nextCursor must be a non-empty string when hasMore is true."
+      );
+    }
+
+    if (meta.exhaustive === true) {
+      addError(
+        "pagination_exhaustive_conflict",
+        "$.meta.pagination",
+        "A result with more pages cannot also be exhaustive."
+      );
+    }
+  } else if (
+    pagination.nextCursor !== undefined &&
+    pagination.nextCursor !== null &&
+    !isNonEmptyString(pagination.nextCursor)
+  ) {
+    addError(
+      "invalid_pagination_next_cursor",
+      "$.meta.pagination.nextCursor",
+      "meta.pagination.nextCursor must be a non-empty string or null when present."
+    );
+  }
+
+  if (
+    pagination.pageSize !== undefined &&
+    !isNonNegativeSafeInteger(pagination.pageSize)
+  ) {
+    addError(
+      "invalid_pagination_page_size",
+      "$.meta.pagination.pageSize",
+      "meta.pagination.pageSize must be a non-negative safe integer when present."
+    );
+  }
+}

--- a/convex/component/toolGuidance.test.ts
+++ b/convex/component/toolGuidance.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import {
+  buildSystemPromptWithTools,
+  buildToolReliabilityGuidance,
+} from "./toolGuidance";
+import {
+  defineCountTool,
+  definePaginatedListTool,
+  defineSemanticSearchTool,
+  type DatabaseChatTool,
+} from "./tools";
+
+describe("tool guidance", () => {
+  it("generates reliability guidance from tool metadata kinds", () => {
+    const tools = [
+      defineCountTool({
+        name: "countRecords",
+        description: "Count records.",
+        handler: "count_handler",
+      }),
+      definePaginatedListTool({
+        name: "listRecords",
+        description: "List records.",
+        handler: "list_handler",
+      }),
+      defineSemanticSearchTool({
+        name: "semanticSearchRecords",
+        description: "Find semantically relevant records.",
+        handler: "semantic_handler",
+      }),
+      {
+        name: "rawTool",
+        description: "Raw app-owned tool.",
+        parameters: { type: "object", properties: {} },
+        handler: "raw_handler",
+      } satisfies DatabaseChatTool,
+    ];
+
+    const guidance = buildToolReliabilityGuidance(tools);
+
+    expect(guidance).toContain("Use count tools");
+    expect(guidance).toContain("meta.count");
+    expect(guidance).toContain("Paginated list tools");
+    expect(guidance).toContain("meta.pagination.nextCursor");
+    expect(guidance).toContain("Semantic search tools");
+    expect(guidance).toContain("Do not use semantic search result length");
+    expect(guidance).toContain("Tools without metadata");
+    expect(guidance).toContain("result metadata for that specific call is authoritative");
+  });
+
+  it("appends automatic, disabled, or custom guidance to the system prompt", () => {
+    const tools = [
+      defineCountTool({
+        name: "countRecords",
+        description: "Count records.",
+        handler: "count_handler",
+      }),
+    ];
+
+    const automatic = buildSystemPromptWithTools("Base prompt.", tools);
+    expect(automatic).toContain("You have access to the following tools");
+    expect(automatic).toContain("- countRecords: Count records.");
+    expect(automatic).toContain("Tool result reliability:");
+
+    const disabled = buildSystemPromptWithTools("Base prompt.", tools, {
+      toolGuidance: "disabled",
+    });
+    expect(disabled).toContain("- countRecords: Count records.");
+    expect(disabled).not.toContain("Tool result reliability:");
+
+    const custom = buildSystemPromptWithTools("Base prompt.", tools, {
+      toolGuidance: "Always mention exact scope labels.",
+    });
+    expect(custom).toContain("Always mention exact scope labels.");
+    expect(custom).not.toContain("Tool result reliability:");
+  });
+});

--- a/convex/component/toolGuidance.ts
+++ b/convex/component/toolGuidance.ts
@@ -1,0 +1,94 @@
+import type { DatabaseChatTool, DatabaseChatToolKind } from "./tools";
+
+export type ToolGuidanceOption = "auto" | "disabled" | (string & {});
+
+export function getToolKind(tool: DatabaseChatTool): DatabaseChatToolKind {
+  return tool.metadata?.kind ?? "unknown";
+}
+
+export function buildToolReliabilityGuidance(
+  tools: DatabaseChatTool[]
+): string {
+  if (tools.length === 0) {
+    return "";
+  }
+
+  const kinds = new Set<DatabaseChatToolKind>(tools.map(getToolKind));
+  const lines: string[] = [];
+
+  if (kinds.has("count")) {
+    lines.push(
+      "- Use count tools for factual total/count questions. Prefer `meta.count` when present."
+    );
+  }
+
+  if (kinds.has("paginated_list")) {
+    lines.push(
+      "- Paginated list tools return deterministic rows, but may only return one page. If `meta.pagination.hasMore` is true, say that more results are available."
+    );
+    lines.push(
+      "- When the user asks for more results from a paginated list, call the same tool again with the previous `meta.pagination.nextCursor` and the same relevant filters."
+    );
+  }
+
+  if (kinds.has("semantic_search")) {
+    lines.push(
+      "- Semantic search tools return sampled top-K relevance results. Do not use semantic search result length as a factual count."
+    );
+  }
+
+  if (kinds.has("unknown")) {
+    lines.push(
+      "- Tools without metadata may be incomplete, sampled, or app-specific. Do not infer totals from returned row count unless the result explicitly includes `meta.count`."
+    );
+  }
+
+  lines.push(
+    "- For any standard result contract, the result metadata for that specific call is authoritative. Do not infer totals from `data.length` when `meta.sampled`, `meta.truncated`, or `meta.exhaustive === false`."
+  );
+
+  return `Tool result reliability:\n\n${lines.join("\n")}`;
+}
+
+export function buildSystemPromptWithTools(
+  basePrompt: string,
+  tools: DatabaseChatTool[],
+  options?: { toolGuidance?: ToolGuidanceOption }
+): string {
+  if (tools.length === 0) {
+    return basePrompt;
+  }
+
+  const sections = [
+    basePrompt,
+    buildToolDescriptionSection(tools),
+    resolveToolGuidance(tools, options?.toolGuidance),
+  ].filter((section) => section.trim().length > 0);
+
+  return sections.join("\n\n");
+}
+
+export function buildToolDescriptionSection(
+  tools: DatabaseChatTool[]
+): string {
+  const toolDescriptions = tools
+    .map((tool) => `- ${tool.name}: ${tool.description}`)
+    .join("\n");
+
+  return `You have access to the following tools to query the database:\n${toolDescriptions}\n\nUse these tools to answer questions about the data. You can call multiple tools if needed.`;
+}
+
+export function resolveToolGuidance(
+  tools: DatabaseChatTool[],
+  toolGuidance: ToolGuidanceOption | undefined
+): string {
+  if (toolGuidance === "disabled") {
+    return "";
+  }
+
+  if (toolGuidance && toolGuidance !== "auto") {
+    return toolGuidance;
+  }
+
+  return buildToolReliabilityGuidance(tools);
+}

--- a/convex/component/tools.test.ts
+++ b/convex/component/tools.test.ts
@@ -225,6 +225,11 @@ describe("tools", () => {
           filters: { status: 123, owner: "alice" },
         })
       ).toBe("Field filters.status expected string, got number");
+      expect(
+        validateToolArgs(tool, {
+          filters: { status: "active", unexpected: "value" },
+        })
+      ).toBe("Unknown field: filters.unexpected");
     });
 
     it("defines a paginated list tool with default cursor args and typed injected args", () => {
@@ -267,6 +272,12 @@ describe("tools", () => {
       expect(tool.parameters.properties.limit.description).toContain(
         "default: 25, max: 75"
       );
+      expect(validateToolArgs(tool, { limit: 76 })).toBe(
+        "Field limit must be <= 75"
+      );
+      expect(
+        validateToolArgs(tool, { filters: { createdAfter: -1 } })
+      ).toBe("Field filters.createdAfter must be >= 0");
 
       type ModelArgs = InferToolModelArgs<typeof tool>;
       type HandlerArgs = InferToolHandlerArgs<typeof tool>;

--- a/convex/component/tools.test.ts
+++ b/convex/component/tools.test.ts
@@ -102,6 +102,23 @@ describe("tools", () => {
       expect(error).toBeNull();
     });
 
+    it("rejects top-level extra fields when additionalProperties is false", () => {
+      const closedTool: DatabaseChatTool = {
+        ...sampleTool,
+        parameters: {
+          ...sampleTool.parameters,
+          additionalProperties: false,
+        },
+      };
+
+      const error = validateToolArgs(closedTool, {
+        skill: "JavaScript",
+        extraField: "value",
+      });
+
+      expect(error).toBe("Unknown field: extraField");
+    });
+
     it("allows null for optional fields", () => {
       const error = validateToolArgs(sampleTool, { skill: "JavaScript", limit: null });
       expect(error).toBeNull();

--- a/convex/component/tools.test.ts
+++ b/convex/component/tools.test.ts
@@ -1,6 +1,8 @@
 /// <reference types="vite/client" />
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, expectTypeOf } from "vitest";
 import {
+  booleanFilter,
+  definePaginatedListTool,
   formatToolsForLLM,
   findTool,
   validateToolArgs,
@@ -8,8 +10,18 @@ import {
   createCountTool,
   createAggregateTool,
   createSearchTool,
+  defineCountTool,
+  enumFilter,
+  injectedString,
+  numberFilter,
+  defineSemanticSearchTool,
+  stringFilter,
   type DatabaseChatTool,
+  type InferToolHandlerArgs,
+  type InferToolModelArgs,
+  type InferToolResult,
 } from "./tools";
+import type { DatabaseChatToolResult } from "./resultContract";
 
 describe("tools", () => {
   const sampleTool: DatabaseChatTool = {
@@ -94,6 +106,14 @@ describe("tools", () => {
       const error = validateToolArgs(sampleTool, { skill: "JavaScript", limit: null });
       expect(error).toBeNull();
     });
+
+    it("allows null for optional enum fields", () => {
+      const error = validateToolArgs(sampleTool, {
+        skill: "JavaScript",
+        status: null,
+      });
+      expect(error).toBeNull();
+    });
   });
 
   describe("createQueryTableTool", () => {
@@ -153,5 +173,156 @@ describe("tools", () => {
       expect(tool.parameters.required).toContain("query");
     });
   });
-});
 
+  describe("typed tool builders", () => {
+    it("defines a count tool with nested app-owned filters and standard metadata", () => {
+      const tool = defineCountTool({
+        name: "countRecords",
+        description: "Count records matching filters.",
+        handler: "handler_string",
+        filters: {
+          status: enumFilter({
+            values: ["active", "inactive"] as const,
+            description: "Record status.",
+            required: true,
+          }),
+          owner: stringFilter({ description: "Owner name." }),
+        },
+      });
+
+      expect(tool).toMatchObject({
+        name: "countRecords",
+        description: "Count records matching filters.",
+        handler: "handler_string",
+        metadata: {
+          kind: "count",
+          resultContract: "standard",
+        },
+      });
+      expect(tool.parameters.required).toEqual(["filters"]);
+      expect(tool.parameters.properties).not.toHaveProperty("limit");
+      expect(tool.parameters.properties.filters).toMatchObject({
+        type: "object",
+        required: ["status"],
+        properties: {
+          status: {
+            type: "string",
+            enum: ["active", "inactive"],
+            description: "Record status.",
+          },
+          owner: {
+            type: "string",
+            description: "Owner name.",
+          },
+        },
+      });
+
+      expect(validateToolArgs(tool, { filters: { owner: "alice" } })).toBe(
+        "Missing required field: filters.status"
+      );
+      expect(
+        validateToolArgs(tool, {
+          filters: { status: 123, owner: "alice" },
+        })
+      ).toBe("Field filters.status expected string, got number");
+    });
+
+    it("defines a paginated list tool with default cursor args and typed injected args", () => {
+      type RecordRow = { id: string; title: string };
+
+      const tool = definePaginatedListTool<RecordRow>({
+        name: "listRecords",
+        description: "List records matching deterministic filters.",
+        handler: "handler_string",
+        filters: {
+          createdAfter: numberFilter({
+            min: 0,
+            description: "Only include records after this timestamp.",
+          }),
+          archived: booleanFilter({ description: "Whether the row is archived." }),
+        },
+        injectedArgs: {
+          tenantId: injectedString({
+            description: "Current tenant id, injected by the app.",
+          }),
+        },
+        pagination: {
+          defaultLimit: 25,
+          maxLimit: 75,
+        },
+      });
+
+      expect(tool.metadata).toEqual({
+        kind: "paginated_list",
+        resultContract: "standard",
+      });
+      expect(tool.parameters.properties).toHaveProperty("filters");
+      expect(tool.parameters.properties).toHaveProperty("cursor");
+      expect(tool.parameters.properties).toHaveProperty("limit");
+      expect(tool.parameters.properties).not.toHaveProperty("tenantId");
+      expect(tool.parameters.properties.limit).toMatchObject({
+        type: "number",
+        maximum: 75,
+      });
+      expect(tool.parameters.properties.limit.description).toContain(
+        "default: 25, max: 75"
+      );
+
+      type ModelArgs = InferToolModelArgs<typeof tool>;
+      type HandlerArgs = InferToolHandlerArgs<typeof tool>;
+      type Result = InferToolResult<typeof tool>;
+
+      expectTypeOf<ModelArgs>().toEqualTypeOf<{
+        filters?: {
+          createdAfter?: number;
+          archived?: boolean;
+        };
+        limit?: number;
+        cursor?: string;
+      }>();
+      expectTypeOf<HandlerArgs>().toEqualTypeOf<{
+        filters?: {
+          createdAfter?: number;
+          archived?: boolean;
+        };
+        limit?: number;
+        cursor?: string;
+        tenantId: string;
+      }>();
+      expectTypeOf<Result>().toEqualTypeOf<DatabaseChatToolResult<RecordRow>>();
+    });
+
+    it("defines a semantic search tool as sampled top-K with query and conservative limits", () => {
+      const tool = defineSemanticSearchTool<{ id: string }>({
+        name: "semanticSearchRecords",
+        description: "Find records by semantic relevance.",
+        handler: "handler_string",
+        filters: {
+          status: stringFilter(),
+        },
+      });
+
+      expect(tool.metadata).toEqual({
+        kind: "semantic_search",
+        resultContract: "standard",
+      });
+      expect(tool.parameters.required).toEqual(["query"]);
+      expect(tool.parameters.properties.query).toMatchObject({
+        type: "string",
+      });
+      expect(tool.parameters.properties.filters).toMatchObject({
+        type: "object",
+        properties: {
+          status: { type: "string" },
+        },
+      });
+      expect(tool.parameters.properties.limit).toMatchObject({
+        type: "number",
+        maximum: 50,
+      });
+      expect(tool.parameters.properties.limit.description).toContain(
+        "default: 10, max: 50"
+      );
+    });
+  });
+});

--- a/convex/component/tools.test.ts
+++ b/convex/component/tools.test.ts
@@ -334,6 +334,7 @@ describe("tools", () => {
         kind: "semantic_search",
         resultContract: "standard",
       });
+      expect(tool.handlerType).toBe("action");
       expect(tool.parameters.required).toEqual(["query"]);
       expect(tool.parameters.properties.query).toMatchObject({
         type: "string",
@@ -351,6 +352,17 @@ describe("tools", () => {
       expect(tool.parameters.properties.limit.description).toContain(
         "default: 10, max: 50"
       );
+    });
+
+    it("allows semantic search tools to override the default action handler type", () => {
+      const tool = defineSemanticSearchTool({
+        name: "semanticSearchFromMaterializedIndex",
+        description: "Find records from a materialized semantic index.",
+        handler: "handler_string",
+        handlerType: "query",
+      });
+
+      expect(tool.handlerType).toBe("query");
     });
   });
 });

--- a/convex/component/tools.ts
+++ b/convex/component/tools.ts
@@ -25,27 +25,44 @@
  */
 
 import { v } from "convex/values";
+import type { DatabaseChatToolResult } from "./resultContract";
 
 // =============================================================================
 // Tool Types
 // =============================================================================
+
+export type ToolParameterPropertySchema = {
+  type: "string" | "number" | "boolean" | "array" | "object";
+  description?: string;
+  enum?: string[];
+  items?: { type: string };
+  properties?: Record<string, ToolParameterPropertySchema>;
+  required?: string[];
+  minimum?: number;
+  maximum?: number;
+  additionalProperties?: boolean;
+};
 
 /**
  * JSON Schema for tool parameters (OpenAI function calling format).
  */
 export interface ToolParameterSchema {
   type: "object";
-  properties: Record<
-    string,
-    {
-      type: "string" | "number" | "boolean" | "array" | "object";
-      description?: string;
-      enum?: string[];
-      items?: { type: string };
-    }
-  >;
+  properties: Record<string, ToolParameterPropertySchema>;
   required?: string[];
 }
+
+export type DatabaseChatToolKind =
+  | "count"
+  | "paginated_list"
+  | "semantic_search"
+  | "detail"
+  | "unknown";
+
+export type DatabaseChatToolMetadata = {
+  kind: DatabaseChatToolKind;
+  resultContract?: "standard";
+};
 
 /**
  * A tool that the LLM can call.
@@ -69,6 +86,11 @@ export interface DatabaseChatTool {
    * mutations (default: "query").
    */
   handler: string;
+  /**
+   * Optional reliability metadata. Raw tools without metadata are treated as
+   * kind "unknown" by prompt guidance.
+   */
+  metadata?: DatabaseChatToolMetadata;
 }
 
 /**
@@ -125,7 +147,233 @@ export const databaseChatToolValidator = v.object({
     v.union(v.literal("query"), v.literal("mutation"), v.literal("action"))
   ),
   handler: v.string(),
+  metadata: v.optional(
+    v.object({
+      kind: v.union(
+        v.literal("count"),
+        v.literal("paginated_list"),
+        v.literal("semantic_search"),
+        v.literal("detail"),
+        v.literal("unknown")
+      ),
+      resultContract: v.optional(v.literal("standard")),
+    })
+  ),
 });
+
+// =============================================================================
+// Typed Tool Builder Types
+// =============================================================================
+
+declare const modelArgsSymbol: unique symbol;
+declare const handlerArgsSymbol: unique symbol;
+declare const resultSymbol: unique symbol;
+
+export type FilterDefinition<
+  Kind extends "string" | "number" | "boolean" | "enum",
+  Value,
+  Required extends boolean = false,
+> = {
+  kind: Kind;
+  description?: string;
+  required?: Required;
+  min?: number;
+  max?: number;
+  values?: readonly string[];
+  readonly __filterValue?: Value;
+};
+
+export type StringFilter<Required extends boolean = false> = FilterDefinition<
+  "string",
+  string,
+  Required
+>;
+
+export type NumberFilter<Required extends boolean = false> = FilterDefinition<
+  "number",
+  number,
+  Required
+>;
+
+export type BooleanFilter<Required extends boolean = false> = FilterDefinition<
+  "boolean",
+  boolean,
+  Required
+>;
+
+export type EnumFilter<
+  Values extends readonly string[],
+  Required extends boolean = false,
+> = FilterDefinition<"enum", Values[number], Required> & {
+  values: Values;
+};
+
+export type AnyFilterDefinition = FilterDefinition<
+  "string" | "number" | "boolean" | "enum",
+  unknown,
+  boolean
+>;
+
+export type FilterDefinitions = Record<string, AnyFilterDefinition>;
+
+export type InjectedArg<Kind extends "string"> = {
+  kind: Kind;
+  description?: string;
+  readonly __injectedValue?: Kind extends "string" ? string : never;
+};
+
+export type InjectedArgDefinitions = Record<string, InjectedArg<"string">>;
+
+export type LimitOptions = {
+  defaultLimit?: number;
+  maxLimit?: number;
+};
+
+export interface DatabaseChatDefinedTool<
+  Kind extends DatabaseChatToolKind,
+  Row,
+  ModelArgs,
+  HandlerArgs,
+> extends DatabaseChatTool {
+  metadata: {
+    kind: Kind;
+    resultContract: "standard";
+  };
+  readonly [modelArgsSymbol]?: ModelArgs;
+  readonly [handlerArgsSymbol]?: HandlerArgs;
+  readonly [resultSymbol]?: DatabaseChatToolResult<Row>;
+}
+
+export type InferToolModelArgs<Tool> = Tool extends {
+  readonly [modelArgsSymbol]?: infer Args;
+}
+  ? Args
+  : Record<string, unknown>;
+
+export type InferToolHandlerArgs<Tool> = Tool extends {
+  readonly [handlerArgsSymbol]?: infer Args;
+}
+  ? Args
+  : Record<string, unknown>;
+
+export type InferToolResult<Tool> = Tool extends {
+  readonly [resultSymbol]?: infer Result;
+}
+  ? Result
+  : unknown;
+
+type FilterValue<TFilter> = TFilter extends { readonly __filterValue?: infer V }
+  ? V
+  : never;
+
+type InjectedValue<TInjected> = TInjected extends {
+  readonly __injectedValue?: infer V;
+}
+  ? V
+  : never;
+
+type RequiredFilterKeys<Filters extends FilterDefinitions> = {
+  [Key in keyof Filters]-?: Filters[Key] extends FilterDefinition<
+    "string" | "number" | "boolean" | "enum",
+    unknown,
+    true
+  >
+    ? Key
+    : never;
+}[keyof Filters];
+
+type OptionalFilterKeys<Filters extends FilterDefinitions> = Exclude<
+  keyof Filters,
+  RequiredFilterKeys<Filters>
+>;
+
+type HasRequiredFilters<Filters extends FilterDefinitions> =
+  [RequiredFilterKeys<Filters>] extends [never] ? false : true;
+
+type FilterArgs<Filters extends FilterDefinitions> = {
+  [Key in RequiredFilterKeys<Filters>]: FilterValue<Filters[Key]>;
+} & {
+  [Key in OptionalFilterKeys<Filters>]?: FilterValue<Filters[Key]>;
+};
+
+type EmptyObject = Record<never, never>;
+
+type Expand<T> = { [Key in keyof T]: T[Key] };
+
+type WithFilters<Filters extends FilterDefinitions> =
+  keyof Filters extends never
+    ? EmptyObject
+    : HasRequiredFilters<Filters> extends true
+      ? { filters: Expand<FilterArgs<Filters>> }
+      : { filters?: Expand<FilterArgs<Filters>> };
+
+type InjectedArgs<Injected extends InjectedArgDefinitions> = {
+  [Key in keyof Injected]: InjectedValue<Injected[Key]>;
+};
+
+type CountModelArgs<Filters extends FilterDefinitions> = Expand<
+  WithFilters<Filters>
+>;
+
+type CountHandlerArgs<
+  Filters extends FilterDefinitions,
+  Injected extends InjectedArgDefinitions,
+> = Expand<CountModelArgs<Filters> & InjectedArgs<Injected>>;
+
+type PaginatedListModelArgs<Filters extends FilterDefinitions> = Expand<
+  WithFilters<Filters> & {
+    limit?: number;
+    cursor?: string;
+  }
+>;
+
+type PaginatedListHandlerArgs<
+  Filters extends FilterDefinitions,
+  Injected extends InjectedArgDefinitions,
+> = Expand<PaginatedListModelArgs<Filters> & InjectedArgs<Injected>>;
+
+type SemanticSearchModelArgs<Filters extends FilterDefinitions> = Expand<
+  WithFilters<Filters> & {
+    query: string;
+    limit?: number;
+  }
+>;
+
+type SemanticSearchHandlerArgs<
+  Filters extends FilterDefinitions,
+  Injected extends InjectedArgDefinitions,
+> = Expand<SemanticSearchModelArgs<Filters> & InjectedArgs<Injected>>;
+
+type BaseToolBuilderOptions<
+  Filters extends FilterDefinitions,
+  Injected extends InjectedArgDefinitions,
+> = {
+  name: string;
+  description: string;
+  handler: string;
+  handlerType?: DatabaseChatTool["handlerType"];
+  filters?: Filters;
+  injectedArgs?: Injected;
+};
+
+export type CountToolBuilderOptions<
+  Filters extends FilterDefinitions = EmptyObject,
+  Injected extends InjectedArgDefinitions = EmptyObject,
+> = BaseToolBuilderOptions<Filters, Injected>;
+
+export type PaginatedListToolBuilderOptions<
+  Filters extends FilterDefinitions = EmptyObject,
+  Injected extends InjectedArgDefinitions = EmptyObject,
+> = BaseToolBuilderOptions<Filters, Injected> & {
+  pagination?: LimitOptions;
+};
+
+export type SemanticSearchToolBuilderOptions<
+  Filters extends FilterDefinitions = EmptyObject,
+  Injected extends InjectedArgDefinitions = EmptyObject,
+> = BaseToolBuilderOptions<Filters, Injected> & {
+  limit?: LimitOptions;
+};
 
 // =============================================================================
 // Tool Helpers
@@ -170,42 +418,385 @@ export function validateToolArgs(
   tool: DatabaseChatTool,
   args: Record<string, unknown>
 ): string | null {
-  const { parameters } = tool;
-  const { properties, required = [] } = parameters;
+  return validateObjectArgs(tool.parameters, args);
+}
 
-  // Check required fields
+function validateObjectArgs(
+  schema: ToolParameterSchema | ToolParameterPropertySchema,
+  args: Record<string, unknown>,
+  path = ""
+): string | null {
+  const properties = schema.properties ?? {};
+  const required = schema.required ?? [];
+
   for (const field of required) {
     if (!(field in args)) {
-      return `Missing required field: ${field}`;
+      return `Missing required field: ${joinPath(path, field)}`;
     }
   }
 
-  // Check field types
   for (const [key, value] of Object.entries(args)) {
-    const schema = properties[key];
-    if (!schema) {
-      // Allow extra fields - LLM might add them
+    const propertySchema = properties[key];
+    if (!propertySchema) {
       continue;
     }
 
-    const expectedType = schema.type;
-    const actualType = Array.isArray(value) ? "array" : typeof value;
-
-    if (expectedType !== actualType) {
-      // Allow null for optional fields
-      if (value === null && !required.includes(key)) {
-        continue;
-      }
-      return `Field ${key} expected ${expectedType}, got ${actualType}`;
+    const fieldPath = joinPath(path, key);
+    const requiredField = required.includes(key);
+    const typeError = validateValueType(propertySchema, value, fieldPath, {
+      required: requiredField,
+    });
+    if (typeError) {
+      return typeError;
+    }
+    if (value === null && !requiredField) {
+      continue;
     }
 
-    // Check enum values
-    if (schema.enum && !schema.enum.includes(value as string)) {
-      return `Field ${key} must be one of: ${schema.enum.join(", ")}`;
+    if (
+      propertySchema.type === "object" &&
+      value !== null &&
+      !Array.isArray(value) &&
+      typeof value === "object" &&
+      propertySchema.properties
+    ) {
+      const nestedError = validateObjectArgs(
+        propertySchema,
+        value as Record<string, unknown>,
+        fieldPath
+      );
+      if (nestedError) {
+        return nestedError;
+      }
+    }
+
+    if (propertySchema.enum && !propertySchema.enum.includes(value as string)) {
+      return `Field ${fieldPath} must be one of: ${propertySchema.enum.join(", ")}`;
     }
   }
 
   return null;
+}
+
+function validateValueType(
+  schema: ToolParameterPropertySchema,
+  value: unknown,
+  path: string,
+  options: { required: boolean }
+): string | null {
+  const expectedType = schema.type;
+  const actualType =
+    value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
+
+  if (expectedType !== actualType) {
+    if (value === null && !options.required) {
+      return null;
+    }
+    return `Field ${path} expected ${expectedType}, got ${actualType}`;
+  }
+
+  return null;
+}
+
+function joinPath(base: string, field: string): string {
+  return base ? `${base}.${field}` : field;
+}
+
+// =============================================================================
+// Typed Tool Builder Helpers
+// =============================================================================
+
+export function stringFilter<const Required extends boolean = false>(
+  options?: {
+    description?: string;
+    required?: Required;
+  }
+): StringFilter<Required> {
+  return {
+    kind: "string",
+    description: options?.description,
+    required: options?.required,
+  };
+}
+
+export function numberFilter<const Required extends boolean = false>(
+  options?: {
+    description?: string;
+    required?: Required;
+    min?: number;
+    max?: number;
+  }
+): NumberFilter<Required> {
+  return {
+    kind: "number",
+    description: options?.description,
+    required: options?.required,
+    min: options?.min,
+    max: options?.max,
+  };
+}
+
+export function booleanFilter<const Required extends boolean = false>(
+  options?: {
+    description?: string;
+    required?: Required;
+  }
+): BooleanFilter<Required> {
+  return {
+    kind: "boolean",
+    description: options?.description,
+    required: options?.required,
+  };
+}
+
+export function enumFilter<
+  const Values extends readonly string[],
+  const Required extends boolean = false,
+>(options: {
+  values: Values;
+  description?: string;
+  required?: Required;
+}): EnumFilter<Values, Required> {
+  return {
+    kind: "enum",
+    values: options.values,
+    description: options.description,
+    required: options.required,
+  };
+}
+
+export function injectedString(options?: {
+  description?: string;
+}): InjectedArg<"string"> {
+  return {
+    kind: "string",
+    description: options?.description,
+  };
+}
+
+export function defineCountTool<
+  Row = unknown,
+  const Filters extends FilterDefinitions = EmptyObject,
+  const Injected extends InjectedArgDefinitions = EmptyObject,
+>(
+  options: CountToolBuilderOptions<Filters, Injected>
+): DatabaseChatDefinedTool<
+  "count",
+  Row,
+  CountModelArgs<Filters>,
+  CountHandlerArgs<Filters, Injected>
+> {
+  return defineDatabaseTool({
+    ...options,
+    kind: "count",
+    resultContract: "standard",
+  }) as DatabaseChatDefinedTool<
+    "count",
+    Row,
+    CountModelArgs<Filters>,
+    CountHandlerArgs<Filters, Injected>
+  >;
+}
+
+export function definePaginatedListTool<
+  Row = unknown,
+  const Filters extends FilterDefinitions = EmptyObject,
+  const Injected extends InjectedArgDefinitions = EmptyObject,
+>(
+  options: PaginatedListToolBuilderOptions<Filters, Injected>
+): DatabaseChatDefinedTool<
+  "paginated_list",
+  Row,
+  PaginatedListModelArgs<Filters>,
+  PaginatedListHandlerArgs<Filters, Injected>
+> {
+  const limits = resolveLimits(options.pagination, {
+    defaultLimit: 20,
+    maxLimit: 100,
+  });
+  return defineDatabaseTool({
+    ...options,
+    kind: "paginated_list",
+    resultContract: "standard",
+    limit: limits,
+    cursor: true,
+  }) as DatabaseChatDefinedTool<
+    "paginated_list",
+    Row,
+    PaginatedListModelArgs<Filters>,
+    PaginatedListHandlerArgs<Filters, Injected>
+  >;
+}
+
+export function defineSemanticSearchTool<
+  Row = unknown,
+  const Filters extends FilterDefinitions = EmptyObject,
+  const Injected extends InjectedArgDefinitions = EmptyObject,
+>(
+  options: SemanticSearchToolBuilderOptions<Filters, Injected>
+): DatabaseChatDefinedTool<
+  "semantic_search",
+  Row,
+  SemanticSearchModelArgs<Filters>,
+  SemanticSearchHandlerArgs<Filters, Injected>
+> {
+  const limits = resolveLimits(options.limit, {
+    defaultLimit: 10,
+    maxLimit: 50,
+  });
+  return defineDatabaseTool({
+    ...options,
+    kind: "semantic_search",
+    resultContract: "standard",
+    query: true,
+    limit: limits,
+  }) as DatabaseChatDefinedTool<
+    "semantic_search",
+    Row,
+    SemanticSearchModelArgs<Filters>,
+    SemanticSearchHandlerArgs<Filters, Injected>
+  >;
+}
+
+function defineDatabaseTool<
+  Filters extends FilterDefinitions,
+  Injected extends InjectedArgDefinitions,
+>(options: BaseToolBuilderOptions<Filters, Injected> & {
+  kind: Exclude<DatabaseChatToolKind, "detail" | "unknown">;
+  resultContract: "standard";
+  query?: boolean;
+  cursor?: boolean;
+  limit?: Required<LimitOptions>;
+}): DatabaseChatTool {
+  const parameters = buildParameters(options);
+
+  return {
+    name: options.name,
+    description: options.description,
+    parameters,
+    handlerType: options.handlerType,
+    handler: options.handler,
+    metadata: {
+      kind: options.kind,
+      resultContract: options.resultContract,
+    },
+  };
+}
+
+function buildParameters<
+  Filters extends FilterDefinitions,
+  Injected extends InjectedArgDefinitions,
+>(
+  options: BaseToolBuilderOptions<Filters, Injected> & {
+    query?: boolean;
+    cursor?: boolean;
+    limit?: Required<LimitOptions>;
+  }
+): ToolParameterSchema {
+  const properties: Record<string, ToolParameterPropertySchema> = {};
+  const required: string[] = [];
+
+  if (options.query) {
+    properties.query = {
+      type: "string",
+      description: "Semantic search query.",
+    };
+    required.push("query");
+  }
+
+  const filters = options.filters ?? ({} as Filters);
+  const filterKeys = Object.keys(filters);
+  if (filterKeys.length > 0) {
+    const filterSchema = buildFiltersSchema(filters);
+    properties.filters = filterSchema;
+    if ((filterSchema.required ?? []).length > 0) {
+      required.push("filters");
+    }
+  }
+
+  if (options.cursor) {
+    properties.cursor = {
+      type: "string",
+      description:
+        "Opaque cursor from the previous result page. Omit this for the first page.",
+    };
+  }
+
+  if (options.limit) {
+    properties.limit = {
+      type: "number",
+      description: `Maximum number of results to return (default: ${options.limit.defaultLimit}, max: ${options.limit.maxLimit}).`,
+      minimum: 0,
+      maximum: options.limit.maxLimit,
+    };
+  }
+
+  return {
+    type: "object",
+    properties,
+    required,
+  };
+}
+
+function buildFiltersSchema(
+  filters: FilterDefinitions
+): ToolParameterPropertySchema {
+  const properties: Record<string, ToolParameterPropertySchema> = {};
+  const required: string[] = [];
+
+  for (const [name, filter] of Object.entries(filters)) {
+    properties[name] = filterToSchema(filter);
+    if (filter.required === true) {
+      required.push(name);
+    }
+  }
+
+  return {
+    type: "object",
+    description: "App-defined filters to apply.",
+    properties,
+    required,
+    additionalProperties: false,
+  };
+}
+
+function filterToSchema(filter: AnyFilterDefinition): ToolParameterPropertySchema {
+  switch (filter.kind) {
+    case "number":
+      return {
+        type: "number",
+        description: filter.description,
+        minimum: filter.min,
+        maximum: filter.max,
+      };
+    case "boolean":
+      return {
+        type: "boolean",
+        description: filter.description,
+      };
+    case "enum":
+      return {
+        type: "string",
+        description: filter.description,
+        enum: filter.values ? [...filter.values] : [],
+      };
+    case "string":
+    default:
+      return {
+        type: "string",
+        description: filter.description,
+      };
+  }
+}
+
+function resolveLimits(
+  options: LimitOptions | undefined,
+  defaults: Required<LimitOptions>
+): Required<LimitOptions> {
+  return {
+    defaultLimit: options?.defaultLimit ?? defaults.defaultLimit,
+    maxLimit: options?.maxLimit ?? defaults.maxLimit,
+  };
 }
 
 // =============================================================================

--- a/convex/component/tools.ts
+++ b/convex/component/tools.ts
@@ -660,6 +660,7 @@ export function defineSemanticSearchTool<
   });
   return defineDatabaseTool({
     ...options,
+    handlerType: options.handlerType ?? "action",
     kind: "semantic_search",
     resultContract: "standard",
     query: true,

--- a/convex/component/tools.ts
+++ b/convex/component/tools.ts
@@ -138,6 +138,7 @@ export const toolParameterSchemaValidator = v.object({
   type: v.literal("object"),
   properties: v.any(), // Complex nested structure
   required: v.optional(v.array(v.string())),
+  additionalProperties: v.optional(v.boolean()),
 });
 
 export const databaseChatToolValidator = v.object({

--- a/convex/component/tools.ts
+++ b/convex/component/tools.ts
@@ -50,6 +50,7 @@ export interface ToolParameterSchema {
   type: "object";
   properties: Record<string, ToolParameterPropertySchema>;
   required?: string[];
+  additionalProperties?: boolean;
 }
 
 export type DatabaseChatToolKind =
@@ -438,6 +439,9 @@ function validateObjectArgs(
   for (const [key, value] of Object.entries(args)) {
     const propertySchema = properties[key];
     if (!propertySchema) {
+      if (schema.additionalProperties === false) {
+        return `Unknown field: ${joinPath(path, key)}`;
+      }
       continue;
     }
 
@@ -493,6 +497,15 @@ function validateValueType(
       return null;
     }
     return `Field ${path} expected ${expectedType}, got ${actualType}`;
+  }
+
+  if (expectedType === "number" && typeof value === "number") {
+    if (schema.minimum !== undefined && value < schema.minimum) {
+      return `Field ${path} must be >= ${schema.minimum}`;
+    }
+    if (schema.maximum !== undefined && value > schema.maximum) {
+      return `Field ${path} must be <= ${schema.maximum}`;
+    }
   }
 
   return null;

--- a/docs/content/docs/guides/chat-integration.mdx
+++ b/docs/content/docs/guides/chat-integration.mdx
@@ -12,11 +12,34 @@ delta-based streaming, and message persistence.
 // convex/chat.ts
 import { v } from "convex/values";
 import { action } from "./_generated/server";
-import { components } from "./_generated/api";
+import { createFunctionHandle } from "convex/server";
+import { api, components } from "./_generated/api";
+import {
+  definePaginatedListTool,
+  injectedString,
+} from "@dayhaysoos/convex-database-chat/tools";
+
+async function getTools() {
+  return [
+    definePaginatedListTool({
+      name: "listProducts",
+      description: "List products with deterministic cursor pagination.",
+      handler: await createFunctionHandle(api.chatTools.listProducts),
+      injectedArgs: {
+        orgId: injectedString({
+          description: "Current organization id injected by the app.",
+        }),
+      },
+      pagination: { defaultLimit: 20, maxLimit: 100 },
+    }),
+  ];
+}
 
 export const sendMessage = action({
   args: { conversationId: v.string(), message: v.string() },
   handler: async (ctx, args) => {
+    const tools = await getTools();
+
     return await ctx.runAction(components.databaseChat.chat.send, {
       conversationId: args.conversationId as any,
       message: args.message,
@@ -24,7 +47,7 @@ export const sendMessage = action({
         apiKey: process.env.OPENROUTER_API_KEY!,
         model: "openai/gpt-4o",
         systemPrompt: "You are a helpful assistant.",
-        tools: [],
+        tools,
         maxMessagesForLLM: 50,
         toolContext: { orgId: "org_123" },
       },
@@ -39,8 +62,58 @@ export const sendMessage = action({
 - `model` (optional): defaults to `openai/gpt-4o`.
 - `systemPrompt` (optional): falls back to the component default if omitted.
 - `tools` (optional): array of `DatabaseChatTool`.
+- `toolGuidance` (optional): `"auto"` by default for standard tool-result
+  guidance.
 - `maxMessagesForLLM` (optional): defaults to 50.
 - `toolContext` (optional): server-only context merged into tool args.
+
+`createFunctionHandle` is async, so build tools inside the action handler or in
+a helper called from the handler. Do not call it at module scope.
+
+## Tool guidance
+
+`toolGuidance` controls the reliability instructions the component adds to the
+system prompt after it lists the available tools. These instructions tell the
+LLM how to interpret tool results: use count tools for factual totals, continue
+paginated lists with `nextCursor`, and do not treat semantic top-K result length
+as an exact count.
+
+The default is `"auto"`. In auto mode, the component reads each tool's
+`metadata.kind` and emits guidance for the result categories present in the
+current tool set. Typed builders such as `defineCountTool`,
+`definePaginatedListTool`, and `defineSemanticSearchTool` set this metadata for
+you.
+
+```ts
+config: {
+  apiKey: process.env.OPENROUTER_API_KEY!,
+  tools,
+  toolGuidance: "auto",
+}
+```
+
+You can disable the generated guidance when your system prompt already covers
+tool behavior:
+
+```ts
+config: {
+  apiKey: process.env.OPENROUTER_API_KEY!,
+  tools,
+  toolGuidance: "disabled",
+}
+```
+
+You can also pass a custom string. A custom string replaces the generated
+reliability guidance but is still appended after the tool list.
+
+```ts
+config: {
+  apiKey: process.env.OPENROUTER_API_KEY!,
+  tools,
+  toolGuidance:
+    "Use product count tools for exact totals. Use list cursors for follow-up pages.",
+}
+```
 
 ## External ID scoping
 
@@ -60,6 +133,6 @@ throws `Not found` to avoid leaking existence across tenants.
 
 ## Client wrapper alternative
 
-The `defineDatabaseChat` client (see [Client Wrapper](/docs/reference/client-wrapper))
-wraps the same actions and helps you pass tools and system prompts once instead
-of per call.
+The `defineDatabaseChat` client (see
+[Client Wrapper](/docs/reference/client-wrapper)) wraps the same actions and
+helps you pass tools and system prompts once instead of per call.

--- a/docs/content/docs/guides/example-app.mdx
+++ b/docs/content/docs/guides/example-app.mdx
@@ -11,7 +11,11 @@ The repository includes an e-commerce demo in `example/`.
 
 ## Local setup
 
+The example consumes the repository package through `file:..`, so install the
+root dependencies before installing the example dependencies.
+
 ```bash
+pnpm install
 cd example
 npm install
 ```

--- a/docs/content/docs/guides/example-app.mdx
+++ b/docs/content/docs/guides/example-app.mdx
@@ -32,6 +32,10 @@ npx convex env set OPENROUTER_API_KEY your_key_here
 npm run seed
 ```
 
+This seeds 250 products across `electronics`, `home`, `clothing`, and `sports`.
+If you previously seeded the older 50-product catalog, rerun `npm run seed` to
+insert the missing generated variants.
+
 ```bash
 npm run dev
 ```
@@ -47,3 +51,26 @@ npm run seed:embeddings
 - `npm run convex` - Convex dev server only
 - `npm run dev:ui` - Vite UI only
 - `npm run start` - Serve the production build
+
+## Standard tool QA prompts
+
+Open the chat, toggle the **Tools** panel, and run these prompts:
+
+- `How many electronics are under $50?`
+  - Expected tool: `countProducts`
+  - Expected metadata: `count 30`, `returned 0`, `truncated false`
+- `Show me 5 electronics under $50.`
+  - Expected tool: `listProducts`
+  - Expected metadata: `count 30`, `returned 5`, `hasMore true`
+- `Show more.`
+  - Expected tool: `listProducts` with the previous `cursor`
+- `Find products for a home office setup.`
+  - Expected tool: `semanticSearchProducts`
+  - Expected metadata: `sampled true`, `truncated true`
+- `Use the legacy raw search tool for sports products.`
+  - Expected tool: `rawSearchProducts`
+  - Expected raw array result
+
+These prompts exercise the standard count/list/semantic contracts, hidden
+`toolContext` injection, cursor continuation, semantic action execution, and
+legacy raw-tool compatibility.

--- a/docs/content/docs/guides/system-prompts.mdx
+++ b/docs/content/docs/guides/system-prompts.mdx
@@ -6,6 +6,24 @@ description: Shape assistant behavior with clear instructions.
 The system prompt tells the LLM how to behave. Keep it short, explicit, and
 grounded in your domain.
 
+When tools are configured, DatabaseChat automatically appends generic tool
+reliability guidance by default. This teaches the assistant to use `meta.count`
+for exact totals, treat paginated list results as pages, use
+`meta.pagination.nextCursor` for immediate "show more" follow-ups, and avoid
+using semantic search result length as a factual count.
+
+```ts
+const chat = defineDatabaseChat(components.databaseChat, {
+  systemPrompt: SYSTEM_PROMPT,
+  tools,
+  toolGuidance: "auto", // default
+});
+```
+
+Use `toolGuidance: "disabled"` if your system prompt fully owns those rules, or
+pass a custom string to append your own tool-result instructions instead of the
+generated guidance.
+
 ## Suggested structure
 
 ```

--- a/docs/content/docs/guides/tools.mdx
+++ b/docs/content/docs/guides/tools.mdx
@@ -74,6 +74,99 @@ If you want generic tools, the component includes helpers:
 
 Each helper returns a `DatabaseChatTool` and still requires a handler string.
 
+## Typed standard-result tools
+
+For tools that return the standard result contract, prefer the split builders.
+They generate the same `DatabaseChatTool` shape, attach reliability metadata,
+and keep model-visible filters nested under `filters`.
+
+```ts
+import {
+  defineCountTool,
+  definePaginatedListTool,
+  defineSemanticSearchTool,
+  enumFilter,
+  injectedString,
+  numberFilter,
+  stringFilter,
+  type InferToolHandlerArgs,
+  type InferToolResult,
+} from "@dayhaysoos/convex-database-chat/tools";
+import type { DatabaseChatToolResult } from "@dayhaysoos/convex-database-chat/resultContract";
+
+type ProductRow = {
+  id: string;
+  name: string;
+  price: number;
+  viewUrl: string;
+};
+
+export const listProductsTool = definePaginatedListTool<ProductRow>({
+  name: "listProducts",
+  description: "List products matching deterministic filters.",
+  handler: "handler_string",
+  filters: {
+    category: enumFilter({
+      values: ["electronics", "clothing", "home", "sports"] as const,
+      description: "Product category.",
+    }),
+    minPrice: numberFilter({ min: 0 }),
+    searchQuery: stringFilter(),
+  },
+  injectedArgs: {
+    tenantId: injectedString(),
+  },
+  pagination: {
+    defaultLimit: 20,
+    maxLimit: 100,
+  },
+});
+
+type HandlerArgs = InferToolHandlerArgs<typeof listProductsTool>;
+type HandlerResult = InferToolResult<typeof listProductsTool>;
+// HandlerResult is DatabaseChatToolResult<ProductRow>.
+```
+
+The LLM sees `filters`, `limit`, and `cursor`. It does not see injected args
+such as `tenantId`; those still appear in handler arg inference and can be
+merged from `toolContext`.
+
+Builder defaults:
+
+- `defineCountTool`: exact totals, no `limit`.
+- `definePaginatedListTool`: deterministic cursor pages, default limit 20, max 100.
+- `defineSemanticSearchTool`: sampled top-K relevance results, default limit 10, max 50.
+
+## Standard result contract
+
+Handlers for standard-result tools should return:
+
+```ts
+const result: DatabaseChatToolResult<ProductRow> = {
+  data: rows,
+  meta: {
+    scope: { type: "workspace", id: workspaceId },
+    appliedFilters: normalizedFilters,
+    count: exactCount,
+    returned: rows.length,
+    exhaustive: false,
+    truncated: true,
+    truncationReason: "row_limit",
+    sampled: false,
+    pagination: {
+      cursor,
+      hasMore: nextCursor !== null,
+      nextCursor,
+      pageSize: limit,
+    },
+  },
+};
+```
+
+Use `validateToolResultContract(result)` in tests or development checks when
+you want structured errors for contract invariants such as
+`meta.returned === data.length`.
+
 ## Auto-generated tools
 
 You can generate tools from schema-like definitions with `generateToolsFromSchema`.

--- a/docs/content/docs/guides/tools.mdx
+++ b/docs/content/docs/guides/tools.mdx
@@ -4,8 +4,8 @@ description: Define what the LLM can query.
 ---
 
 Tools describe the queries and actions your assistant can call. Each tool
-declares a name, description, JSON schema for parameters, and a handler
-string created with `createFunctionHandle`.
+declares a name, description, JSON schema for parameters, and a handler string
+created with `createFunctionHandle`.
 
 ## Tool shape
 
@@ -28,11 +28,46 @@ interface DatabaseChatTool {
   };
   handlerType?: "query" | "mutation" | "action";
   handler: string;
+  metadata?: {
+    kind: "count" | "paginated_list" | "semantic_search" | "detail" | "unknown";
+    resultContract?: "standard";
+  };
 }
 ```
 
-`handlerType` defaults to `"query"`. Use `"action"` for tools that call
-`ctx.vectorSearch` or external APIs.
+Raw tools default `handlerType` to `"query"`. Use `"action"` for tools that call
+`ctx.vectorSearch` or external APIs. The typed semantic builder defaults to
+`"action"` because semantic search commonly uses Convex actions.
+
+## Tool metadata
+
+`metadata` tells the component what kind of result a tool returns. It is not a
+model-visible argument and it is not app domain data. For example, do not use
+`kind` for values like `"product"` or `"candidate"`. Use it to describe the
+tool's result semantics.
+
+Typed standard-result builders set metadata automatically. If you define raw
+tools by hand, add metadata when the component should be able to generate better
+tool guidance. If metadata is omitted, the tool is treated as `"unknown"`.
+
+| Field                     | Meaning                                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| `metadata.kind`           | The result category the component uses for prompt guidance and tool reliability semantics.      |
+| `metadata.resultContract` | Set to `"standard"` only when the handler returns `{ data, meta }` as `DatabaseChatToolResult`. |
+
+Supported `kind` values:
+
+| Kind                | Use for                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------ |
+| `"count"`           | Exact total/count tools. The authoritative answer is usually `meta.count`.                 |
+| `"paginated_list"`  | Deterministic list tools that may return one cursor page at a time.                        |
+| `"semantic_search"` | Top-K relevance tools. Results are sampled and should not be interpreted as exact totals.  |
+| `"detail"`          | One-record detail lookups. This is useful for classifying exact detail fetches.            |
+| `"unknown"`         | Raw or app-specific tools where the component should not assume count or pagination rules. |
+
+Use `metadata.resultContract: "standard"` only for handlers that return the
+standard result contract described below. Do not set it for legacy raw arrays,
+raw objects, or vector helpers that return a plain array.
 
 ## Explicit tool example
 
@@ -41,27 +76,32 @@ import { createFunctionHandle } from "convex/server";
 import { api } from "./_generated/api";
 import type { DatabaseChatTool } from "./components/databaseChat/tools";
 
-const tools: DatabaseChatTool[] = [
-  {
-    name: "searchProducts",
-    description: "Search products by name, category, or price range",
-    parameters: {
-      type: "object",
-      properties: {
-        query: { type: "string", description: "Search text" },
-        category: {
-          type: "string",
-          enum: ["electronics", "clothing", "home", "sports"],
+async function getTools(): Promise<DatabaseChatTool[]> {
+  return [
+    {
+      name: "searchProducts",
+      description: "Search products by name, category, or price range",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search text" },
+          category: {
+            type: "string",
+            enum: ["electronics", "clothing", "home", "sports"],
+          },
+          minPrice: { type: "number" },
+          maxPrice: { type: "number" },
+          limit: { type: "number" },
         },
-        minPrice: { type: "number" },
-        maxPrice: { type: "number" },
-        limit: { type: "number" },
       },
+      handler: await createFunctionHandle(api.chatTools.searchProducts),
     },
-    handler: createFunctionHandle(api.chatTools.searchProducts),
-  },
-];
+  ];
+}
 ```
+
+`createFunctionHandle` is asynchronous and should be called inside a Convex
+function, usually from a small `getTools()` helper used by your chat action.
 
 ## Built-in helpers
 
@@ -134,8 +174,10 @@ merged from `toolContext`.
 Builder defaults:
 
 - `defineCountTool`: exact totals, no `limit`.
-- `definePaginatedListTool`: deterministic cursor pages, default limit 20, max 100.
-- `defineSemanticSearchTool`: sampled top-K relevance results, default limit 10, max 50.
+- `definePaginatedListTool`: deterministic cursor pages, default limit 20,
+  max 100.
+- `defineSemanticSearchTool`: sampled top-K relevance results, default limit 10,
+  max 50, and `handlerType: "action"` unless explicitly overridden.
 
 ## Standard result contract
 
@@ -163,17 +205,59 @@ const result: DatabaseChatToolResult<ProductRow> = {
 };
 ```
 
-Use `validateToolResultContract(result)` in tests or development checks when
-you want structured errors for contract invariants such as
+Use `validateToolResultContract(result)` in tests or development checks when you
+want structured errors for contract invariants such as
 `meta.returned === data.length`.
+
+### Pagination semantics
+
+For deterministic lists, `meta.count` is the total number of matching rows and
+`meta.returned` is the number returned in this page. If
+`meta.pagination.hasMore` is true, pass `meta.pagination.nextCursor` back as the
+next call's `cursor`.
+
+For example, a first page can return:
+
+```json
+{
+  "data": [{ "id": "1", "name": "USB-C Hub" }],
+  "meta": {
+    "count": 30,
+    "returned": 1,
+    "exhaustive": false,
+    "truncated": true,
+    "sampled": false,
+    "pagination": {
+      "cursor": null,
+      "hasMore": true,
+      "nextCursor": "1",
+      "pageSize": 1
+    }
+  }
+}
+```
+
+An immediate "show more" follow-up should call the same list tool with the same
+`filters` and `cursor: "1"`. The final page should return `hasMore: false`.
+
+### Semantic search semantics
+
+Semantic search tools should set `meta.sampled: true`, `meta.exhaustive: false`,
+and a `sampleMethod` such as `"semantic_top_k"`. A semantic result's
+`data.length` is the number of top-K results returned, not an exact count of all
+possible matches. Use a count tool for factual totals.
 
 ## Auto-generated tools
 
-You can generate tools from schema-like definitions with `generateToolsFromSchema`.
+You can generate tools from schema-like definitions with
+`generateToolsFromSchema`.
 
 ```ts
 import { createFunctionHandle } from "convex/server";
-import { defineTable, generateToolsFromSchema } from "./components/databaseChat/schemaTools";
+import {
+  defineTable,
+  generateToolsFromSchema,
+} from "./components/databaseChat/schemaTools";
 import { api } from "./_generated/api";
 
 const tables = [
@@ -184,15 +268,17 @@ const tables = [
   ]),
 ];
 
-const tools = generateToolsFromSchema({
-  tables,
-  allowedTables: ["products"],
-  handlers: {
-    query: createFunctionHandle(api.chatTools.queryTable),
-    count: createFunctionHandle(api.chatTools.countRecords),
-    aggregate: createFunctionHandle(api.chatTools.aggregate),
-  },
-});
+async function getSchemaTools() {
+  return generateToolsFromSchema({
+    tables,
+    allowedTables: ["products"],
+    handlers: {
+      query: await createFunctionHandle(api.chatTools.queryTable),
+      count: await createFunctionHandle(api.chatTools.countRecords),
+      aggregate: await createFunctionHandle(api.chatTools.aggregate),
+    },
+  });
+}
 ```
 
 `AutoToolsConfig` lets you restrict tables and hide fields:

--- a/docs/content/docs/guides/vector-search.mdx
+++ b/docs/content/docs/guides/vector-search.mdx
@@ -50,4 +50,7 @@ const tools = [
 ];
 ```
 
-`defineVectorSearchTool` sets `handlerType` to `"action"` automatically.
+`defineVectorSearchTool` sets `handlerType` to `"action"` and
+`metadata.kind` to `"semantic_search"` automatically. It does not set
+`metadata.resultContract` because `formatVectorResults` returns an array, not
+the standard `{ data, meta }` result envelope.

--- a/docs/content/docs/guides/vector-search.mdx
+++ b/docs/content/docs/guides/vector-search.mdx
@@ -41,16 +41,26 @@ import { defineVectorSearchTool } from "@dayhaysoos/convex-database-chat/vector"
 import { createFunctionHandle } from "convex/server";
 import { api } from "./_generated/api";
 
-const tools = [
-  defineVectorSearchTool({
-    name: "semanticSearch",
-    description: "Find candidates by meaning or concept",
-    handler: createFunctionHandle(api.chatTools.semanticSearchCandidates),
-  }),
-];
+async function getTools() {
+  return [
+    defineVectorSearchTool({
+      name: "semanticSearch",
+      description: "Find candidates by meaning or concept",
+      handler: await createFunctionHandle(
+        api.chatTools.semanticSearchCandidates,
+      ),
+    }),
+  ];
+}
 ```
 
-`defineVectorSearchTool` sets `handlerType` to `"action"` and
-`metadata.kind` to `"semantic_search"` automatically. It does not set
-`metadata.resultContract` because `formatVectorResults` returns an array, not
-the standard `{ data, meta }` result envelope.
+`defineVectorSearchTool` sets `handlerType` to `"action"` and `metadata.kind` to
+`"semantic_search"` automatically. It does not set `metadata.resultContract`
+because `formatVectorResults` returns an array, not the standard
+`{ data, meta }` result envelope.
+
+If you want semantic search to participate in the standard result contract and
+automatic reliability guidance, use `defineSemanticSearchTool` from
+`@dayhaysoos/convex-database-chat/tools` instead. That builder also defaults to
+`handlerType: "action"`, but expects your handler to return `{ data, meta }`
+with `meta.sampled: true` and `meta.exhaustive: false`.

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -105,6 +105,10 @@ export const sendMessage = action({
 });
 ```
 
+Raw tools keep working. For count/list/semantic tools that return the standard
+`{ data, meta }` result contract, see [Tools](/docs/guides/tools) for typed
+builders that attach reliability metadata and enable automatic result guidance.
+
 ## 3. Add a minimal UI
 
 ```tsx

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: Minimal end-to-end setup using the client wrapper.
+description: Minimal end-to-end setup.
 ---
 
 ## 1. Define a tool
@@ -31,7 +31,8 @@ export const countRecords = query({
 
 ## 2. Wire the chat endpoints
 
-Use `defineDatabaseChat` to create a typed wrapper around the component.
+Create function handles inside a Convex function, then pass your tools to the
+component chat action.
 
 ```ts
 // convex/chat.ts
@@ -39,69 +40,101 @@ import { v } from "convex/values";
 import { action, mutation, query } from "./_generated/server";
 import { createFunctionHandle } from "convex/server";
 import { components, api } from "./_generated/api";
-import { defineDatabaseChat } from "./components/databaseChat/client";
 import type { DatabaseChatTool } from "./components/databaseChat/tools";
 
-const tools: DatabaseChatTool[] = [
-  {
-    name: "countRecords",
-    description: "Count records in a table. Available tables: users, orders",
-    parameters: {
-      type: "object",
-      properties: {
-        table: { type: "string", enum: ["users", "orders"] },
+async function getTools(): Promise<DatabaseChatTool[]> {
+  return [
+    {
+      name: "countRecords",
+      description: "Count records in a table. Available tables: users, orders",
+      parameters: {
+        type: "object",
+        properties: {
+          table: { type: "string", enum: ["users", "orders"] },
+        },
+        required: ["table"],
       },
-      required: ["table"],
+      handler: await createFunctionHandle(api.chatTools.countRecords),
     },
-    handler: createFunctionHandle(api.chatTools.countRecords),
-  },
-];
-
-const chat = defineDatabaseChat(components.databaseChat, {
-  tools,
-  systemPrompt:
-    "You are a helpful assistant. Use the available tools to answer questions about the database.",
-});
+  ];
+}
 
 export const createConversation = mutation({
   args: { externalId: v.string(), title: v.optional(v.string()) },
-  handler: async (ctx, args) => chat.createConversation(ctx, args),
+  handler: async (ctx, args) => {
+    return await ctx.runMutation(components.databaseChat.conversations.create, {
+      externalId: args.externalId,
+      title: args.title ?? "New Chat",
+    });
+  },
 });
 
 export const listConversations = query({
   args: { externalId: v.string() },
-  handler: async (ctx, args) => chat.listConversations(ctx, args.externalId),
+  handler: async (ctx, args) => {
+    return await ctx.runQuery(components.databaseChat.conversations.list, {
+      externalId: args.externalId,
+    });
+  },
 });
 
 export const getMessages = query({
   args: { conversationId: v.string() },
-  handler: async (ctx, args) => chat.getMessages(ctx, args.conversationId),
+  handler: async (ctx, args) => {
+    return await ctx.runQuery(components.databaseChat.messages.list, {
+      conversationId: args.conversationId as any,
+    });
+  },
 });
 
 export const getStreamState = query({
   args: { conversationId: v.string() },
-  handler: async (ctx, args) => chat.getStreamState(ctx, args.conversationId),
+  handler: async (ctx, args) => {
+    return await ctx.runQuery(components.databaseChat.stream.getStream, {
+      conversationId: args.conversationId as any,
+    });
+  },
 });
 
 export const getStreamDeltas = query({
   args: { streamId: v.string(), cursor: v.number() },
-  handler: async (ctx, args) => chat.getStreamDeltas(ctx, args.streamId, args.cursor),
+  handler: async (ctx, args) => {
+    return await ctx.runQuery(components.databaseChat.stream.listDeltas, {
+      streamId: args.streamId as any,
+      cursor: args.cursor,
+    });
+  },
 });
 
 export const abortStream = mutation({
   args: { conversationId: v.string(), reason: v.optional(v.string()) },
-  handler: async (ctx, args) =>
-    chat.abortStream(ctx, args.conversationId, args.reason ?? "User cancelled"),
+  handler: async (ctx, args) => {
+    return await ctx.runMutation(
+      components.databaseChat.stream.abortByConversation,
+      {
+        conversationId: args.conversationId as any,
+        reason: args.reason ?? "User cancelled",
+      },
+    );
+  },
 });
 
 export const sendMessage = action({
   args: { conversationId: v.string(), message: v.string() },
-  handler: async (ctx, args) =>
-    chat.send(ctx, {
+  handler: async (ctx, args) => {
+    const tools = await getTools();
+
+    return await ctx.runAction(components.databaseChat.chat.send, {
       conversationId: args.conversationId,
       message: args.message,
-      apiKey: process.env.OPENROUTER_API_KEY!,
-    }),
+      config: {
+        apiKey: process.env.OPENROUTER_API_KEY!,
+        systemPrompt:
+          "You are a helpful assistant. Use the available tools to answer questions about the database.",
+        tools,
+      },
+    });
+  },
 });
 ```
 
@@ -128,14 +161,8 @@ function ChatWidget() {
     createConversation({ externalId: "user:demo" }).then(setConversationId);
   }, [createConversation]);
 
-  const {
-    messages,
-    streamingContent,
-    isStreaming,
-    isLoading,
-    send,
-    abort,
-  } = useDatabaseChat({ conversationId });
+  const { messages, streamingContent, isStreaming, isLoading, send, abort } =
+    useDatabaseChat({ conversationId });
 
   return (
     <div>

--- a/docs/content/docs/reference/api-reference.mdx
+++ b/docs/content/docs/reference/api-reference.mdx
@@ -5,29 +5,29 @@ description: Component endpoints and React exports.
 
 ## Component functions
 
-| Function | Type | Description |
-| --- | --- | --- |
-| `conversations.create` | Mutation | Create a new conversation |
-| `conversations.get` | Query | Get conversation by ID |
-| `conversations.getForExternalId` | Query | Get conversation by ID scoped to `externalId` |
-| `conversations.list` | Query | List conversations by `externalId` |
-| `messages.add` | Mutation | Add a message |
-| `messages.list` | Query | List messages in a conversation (bounded limit) |
-| `messages.listForExternalId` | Query | List messages scoped to `externalId` |
-| `messages.getLatest` | Query | Get latest message |
-| `messages.getLatestForExternalId` | Query | Get latest message scoped to `externalId` |
-| `stream.create` | Mutation | Create a new stream for delta-based streaming |
-| `stream.addDelta` | Mutation | Add a delta to a stream (returns `boolean`) |
-| `stream.finish` | Mutation | Finish a stream and clean up deltas |
-| `stream.abort` | Mutation | Abort a stream by stream ID |
-| `stream.abortByConversation` | Mutation | Abort a stream by conversation ID |
-| `stream.abortForExternalId` | Mutation | Abort a stream by conversation ID scoped to `externalId` |
-| `stream.getStream` | Query | Get current stream state for a conversation |
-| `stream.getStreamForExternalId` | Query | Get current stream state scoped to `externalId` |
-| `stream.listDeltas` | Query | Get deltas from a cursor position |
-| `stream.listDeltasForExternalId` | Query | Get deltas scoped to `externalId` |
-| `chat.send` | Action | Send a message via OpenRouter |
-| `chat.sendForExternalId` | Action | Send a message scoped to `externalId` |
+| Function                          | Type     | Description                                              |
+| --------------------------------- | -------- | -------------------------------------------------------- |
+| `conversations.create`            | Mutation | Create a new conversation                                |
+| `conversations.get`               | Query    | Get conversation by ID                                   |
+| `conversations.getForExternalId`  | Query    | Get conversation by ID scoped to `externalId`            |
+| `conversations.list`              | Query    | List conversations by `externalId`                       |
+| `messages.add`                    | Mutation | Add a message                                            |
+| `messages.list`                   | Query    | List messages in a conversation (bounded limit)          |
+| `messages.listForExternalId`      | Query    | List messages scoped to `externalId`                     |
+| `messages.getLatest`              | Query    | Get latest message                                       |
+| `messages.getLatestForExternalId` | Query    | Get latest message scoped to `externalId`                |
+| `stream.create`                   | Mutation | Create a new stream for delta-based streaming            |
+| `stream.addDelta`                 | Mutation | Add a delta to a stream (returns `boolean`)              |
+| `stream.finish`                   | Mutation | Finish a stream and clean up deltas                      |
+| `stream.abort`                    | Mutation | Abort a stream by stream ID                              |
+| `stream.abortByConversation`      | Mutation | Abort a stream by conversation ID                        |
+| `stream.abortForExternalId`       | Mutation | Abort a stream by conversation ID scoped to `externalId` |
+| `stream.getStream`                | Query    | Get current stream state for a conversation              |
+| `stream.getStreamForExternalId`   | Query    | Get current stream state scoped to `externalId`          |
+| `stream.listDeltas`               | Query    | Get deltas from a cursor position                        |
+| `stream.listDeltasForExternalId`  | Query    | Get deltas scoped to `externalId`                        |
+| `chat.send`                       | Action   | Send a message via OpenRouter                            |
+| `chat.sendForExternalId`          | Action   | Send a message scoped to `externalId`                    |
 
 ## Stream types
 
@@ -105,6 +105,14 @@ These subpaths avoid importing the React entrypoint from Convex functions.
 
 Built tools set `tool.metadata.kind` to `count`, `paginated_list`, or
 `semantic_search` and set `metadata.resultContract` to `standard`.
+
+Builder defaults:
+
+- `defineCountTool`: `handlerType` inherits the raw tool default, `"query"`.
+- `definePaginatedListTool`: `handlerType` inherits the raw tool default,
+  `"query"`.
+- `defineSemanticSearchTool`: `handlerType` defaults to `"action"` because
+  semantic search typically calls `ctx.vectorSearch` or external embedding APIs.
 
 ### `@dayhaysoos/convex-database-chat/toolGuidance`
 

--- a/docs/content/docs/reference/api-reference.mdx
+++ b/docs/content/docs/reference/api-reference.mdx
@@ -75,3 +75,39 @@ Types:
 - `UseConversationsReturn`
 - `UseSmoothTextOptions`
 - `SmoothTextProps`
+
+## Backend-safe exports
+
+These subpaths avoid importing the React entrypoint from Convex functions.
+
+### `@dayhaysoos/convex-database-chat/resultContract`
+
+- `DatabaseChatToolResult<Row>`
+- `DatabaseChatResultMeta`
+- `DatabaseChatScope`
+- `DatabaseChatResultValidationError`
+- `validateToolResultContract(result)`
+- `isDatabaseChatToolResult(result)`
+
+### `@dayhaysoos/convex-database-chat/tools`
+
+- `defineCountTool`
+- `definePaginatedListTool`
+- `defineSemanticSearchTool`
+- `stringFilter`
+- `numberFilter`
+- `booleanFilter`
+- `enumFilter`
+- `injectedString`
+- `InferToolModelArgs<Tool>`
+- `InferToolHandlerArgs<Tool>`
+- `InferToolResult<Tool>`
+
+Built tools set `tool.metadata.kind` to `count`, `paginated_list`, or
+`semantic_search` and set `metadata.resultContract` to `standard`.
+
+### `@dayhaysoos/convex-database-chat/toolGuidance`
+
+- `buildToolReliabilityGuidance(tools)`
+- `buildSystemPromptWithTools(basePrompt, tools, options?)`
+- `getToolKind(tool)`

--- a/docs/content/docs/reference/client-wrapper.mdx
+++ b/docs/content/docs/reference/client-wrapper.mdx
@@ -23,10 +23,13 @@ const chat = defineDatabaseChat(components.databaseChat, {
 
 - `model`: default model for `chat.send` (default: `openai/gpt-4o`).
 - `systemPrompt`: default prompt for `chat.send`.
-- `toolGuidance`: standard tool-result guidance. Use `"auto"` or omit for generated guidance, `"disabled"` to opt out, or a custom string to append instead.
-- `tools`: explicit tool definitions.
+- `toolGuidance`: standard tool-result guidance. Use `"auto"` or omit for
+  generated guidance, `"disabled"` to opt out, or a custom string to append
+  instead.
+- `tools`: explicit tool definitions with already-created handler strings.
 - `autoTools`: generate tools from schema-like definitions.
-- `maxMessagesForDisplay`: default message limit for `getMessages` (default: 100).
+- `maxMessagesForDisplay`: default message limit for `getMessages` (default:
+  100).
 - `maxMessagesForLLM`: default message limit for LLM context (default: 50).
 
 ## `autoTools` shape
@@ -65,3 +68,11 @@ autoTools: {
 - `getMessagesForLLM(ctx, conversationId, { systemPrompt?, includeTools?, toolGuidance? })`
 - `getTools()` and `getToolsForLLM()`
 - `getSystemPromptWithTools(basePrompt?, toolGuidance?)`
+
+<Callout title="Runtime function handles">
+  Convex `createFunctionHandle(...)` is asynchronous and should be called inside
+  a Convex function. If your app builds tool handles at request time, call
+  `components.databaseChat.chat.send` directly and pass `config.tools` from that
+  action. Use `defineDatabaseChat` when your tool handler strings are already
+  available at construction time.
+</Callout>

--- a/docs/content/docs/reference/client-wrapper.mdx
+++ b/docs/content/docs/reference/client-wrapper.mdx
@@ -12,6 +12,7 @@ import { defineDatabaseChat } from "./components/databaseChat/client";
 const chat = defineDatabaseChat(components.databaseChat, {
   model: "openai/gpt-4o",
   systemPrompt: "You are a helpful assistant.",
+  toolGuidance: "auto",
   tools,
   maxMessagesForDisplay: 100,
   maxMessagesForLLM: 50,
@@ -22,6 +23,7 @@ const chat = defineDatabaseChat(components.databaseChat, {
 
 - `model`: default model for `chat.send` (default: `openai/gpt-4o`).
 - `systemPrompt`: default prompt for `chat.send`.
+- `toolGuidance`: standard tool-result guidance. Use `"auto"` or omit for generated guidance, `"disabled"` to opt out, or a custom string to append instead.
 - `tools`: explicit tool definitions.
 - `autoTools`: generate tools from schema-like definitions.
 - `maxMessagesForDisplay`: default message limit for `getMessages` (default: 100).
@@ -55,11 +57,11 @@ autoTools: {
 - `getStreamState(ctx, conversationId)`
 - `getStreamDeltas(ctx, streamId, cursor)`
 - `abortStream(ctx, conversationId, reason?)`
-- `send(ctx, { conversationId, message, apiKey, model?, systemPrompt?, toolContext? })`
+- `send(ctx, { conversationId, message, apiKey, model?, systemPrompt?, toolGuidance?, toolContext? })`
 
 ## Advanced methods
 
 - `addMessage(ctx, conversationId, role, content, { toolCalls?, toolResults? })`
-- `getMessagesForLLM(ctx, conversationId, { systemPrompt?, includeTools? })`
+- `getMessagesForLLM(ctx, conversationId, { systemPrompt?, includeTools?, toolGuidance? })`
 - `getTools()` and `getToolsForLLM()`
-- `getSystemPromptWithTools(basePrompt?)`
+- `getSystemPromptWithTools(basePrompt?, toolGuidance?)`

--- a/docs/react-router.config.ts
+++ b/docs/react-router.config.ts
@@ -1,20 +1,35 @@
-import type { Config } from '@react-router/dev/config';
-import { glob } from 'node:fs/promises';
-import { createGetUrl, getSlugs } from 'fumadocs-core/source';
+import { readdir } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+import type { Config } from "@react-router/dev/config";
+import { createGetUrl, getSlugs } from "fumadocs-core/source";
 
-const getUrl = createGetUrl('/docs');
+const getUrl = createGetUrl("/docs");
+const docsDir = "content/docs";
+
+async function* walkMdxFiles(dir: string): AsyncGenerator<string> {
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkMdxFiles(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith(".mdx")) {
+      yield relative(docsDir, fullPath).split(sep).join("/");
+    }
+  }
+}
 
 export default {
   ssr: true,
   async prerender({ getStaticPaths }) {
     const paths: string[] = [];
-    const excluded: string[] = ['/api/search'];
+    const excluded: string[] = ["/api/search"];
 
     for (const path of getStaticPaths()) {
       if (!excluded.includes(path)) paths.push(path);
     }
 
-    for await (const entry of glob('**/*.mdx', { cwd: 'content/docs' })) {
+    for await (const entry of walkMdxFiles(docsDir)) {
       paths.push(getUrl(getSlugs(entry)));
     }
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,13 +1,14 @@
 # E-commerce Database Chat Demo
 
-A simple demo showing how to use the `@dayhaysoo/convex-database-chat` component to query an e-commerce product database using natural language.
+A simple demo showing how to use the `@dayhaysoo/convex-database-chat` component
+to query an e-commerce product database using natural language.
 
 ## Features
 
-- 🛒 50 mock e-commerce products across 4 categories
+- 🛒 250 mock e-commerce products across 4 categories
 - 💬 Natural language queries powered by Claude via OpenRouter
 - ⚡ Real-time streaming responses
-- 🔍 Search by name, category, price range
+- 🔍 Count, list, and search by nested filters
 - 🧠 Semantic search with vector embeddings
 - 📊 Get inventory statistics and low-stock alerts
 
@@ -37,7 +38,8 @@ This will prompt you to create a new Convex project and set up your environment.
 
 ### 3. Add OpenRouter API Key
 
-Get an API key from [OpenRouter](https://openrouter.ai/) and add it to your Convex environment:
+Get an API key from [OpenRouter](https://openrouter.ai/) and add it to your
+Convex environment:
 
 ```bash
 npx convex env set OPENROUTER_API_KEY your_key_here
@@ -49,7 +51,9 @@ npx convex env set OPENROUTER_API_KEY your_key_here
 npm run seed
 ```
 
-This populates the database with 50 mock products.
+This populates the database with 250 mock products. If you already seeded the
+older 50-product catalog, this command adds the missing generated variants
+without duplicating existing product names.
 
 ### 5. Generate embeddings for semantic search (optional)
 
@@ -67,8 +71,8 @@ npm run dev
 ```
 
 This builds and watches the local package, then runs both the Convex dev server
-and the Vite UI in one command.
-Open [http://localhost:3000](http://localhost:3000) in your browser.
+and the Vite UI in one command. Open
+[http://localhost:3000](http://localhost:3000) in your browser.
 
 Tip: use the **Tools** button in the chat header to see which tools are being
 called (including semantic search).
@@ -146,7 +150,8 @@ example/
 
 1. **User asks a question** → Sent to Convex action
 2. **Action calls DatabaseChat component** → LLM with tool definitions
-3. **LLM decides to call tools** → e.g., `searchProducts({ category: "electronics" })`
+3. **LLM decides to call tools** → e.g.,
+   `searchProducts({ category: "electronics" })`
 4. **Tool executes Convex query** → Returns product data
 5. **LLM formats response** → With markdown links to products
 6. **Response streamed to UI** → Real-time updates via Convex subscriptions

--- a/example/README.md
+++ b/example/README.md
@@ -15,7 +15,15 @@ A simple demo showing how to use the `@dayhaysoo/convex-database-chat` component
 
 ### 1. Install dependencies
 
+The demo consumes the repository package through `file:..`, so install the root
+dependencies before installing the example dependencies.
+
 ```bash
+# From repo root
+pnpm install
+
+# Then install the example
+cd example
 npm install
 ```
 
@@ -58,7 +66,8 @@ meaning-based results.
 npm run dev
 ```
 
-This runs both the Convex dev server and the Vite UI in one command.
+This builds and watches the local package, then runs both the Convex dev server
+and the Vite UI in one command.
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 Tip: use the **Tools** button in the chat header to see which tools are being
@@ -76,8 +85,8 @@ npm run dev:ui
 
 ## Local package development
 
-If you want the example to use the local package (without publishing), you can
-use the helper script:
+The example already uses the local package through `file:..`. For the older
+`npm link` workflow, you can use the helper script:
 
 ```bash
 # From repo root

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -66,10 +66,21 @@ export declare const components: {
             maxMessagesForLLM?: number;
             model?: string;
             systemPrompt?: string;
+            toolContext?: any;
+            toolGuidance?: string;
             tools?: Array<{
               description: string;
               handler: string;
               handlerType?: "query" | "mutation" | "action";
+              metadata?: {
+                kind:
+                  | "count"
+                  | "paginated_list"
+                  | "semantic_search"
+                  | "detail"
+                  | "unknown";
+                resultContract?: "standard";
+              };
               name: string;
               parameters: {
                 properties: any;
@@ -97,10 +108,21 @@ export declare const components: {
             maxMessagesForLLM?: number;
             model?: string;
             systemPrompt?: string;
+            toolContext?: any;
+            toolGuidance?: string;
             tools?: Array<{
               description: string;
               handler: string;
               handlerType?: "query" | "mutation" | "action";
+              metadata?: {
+                kind:
+                  | "count"
+                  | "paginated_list"
+                  | "semantic_search"
+                  | "detail"
+                  | "unknown";
+                resultContract?: "standard";
+              };
               name: string;
               parameters: {
                 properties: any;

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -83,6 +83,7 @@ export declare const components: {
               };
               name: string;
               parameters: {
+                additionalProperties?: boolean;
                 properties: any;
                 required?: Array<string>;
                 type: "object";
@@ -125,6 +126,7 @@ export declare const components: {
               };
               name: string;
               parameters: {
+                additionalProperties?: boolean;
                 properties: any;
                 required?: Array<string>;
                 type: "object";

--- a/example/convex/chat.ts
+++ b/example/convex/chat.ts
@@ -3,7 +3,17 @@ import { createFunctionHandle } from "convex/server";
 import { action, mutation, query } from "./_generated/server";
 import { components, api } from "./_generated/api";
 import { defineVectorSearchTool } from "@dayhaysoos/convex-database-chat/vector";
-import type { DatabaseChatTool } from "@dayhaysoos/convex-database-chat/tools";
+import {
+  booleanFilter,
+  defineCountTool,
+  definePaginatedListTool,
+  defineSemanticSearchTool,
+  enumFilter,
+  injectedString,
+  numberFilter,
+  stringFilter,
+  type DatabaseChatTool,
+} from "@dayhaysoos/convex-database-chat/tools";
 
 // =============================================================================
 // System Prompt
@@ -12,7 +22,8 @@ import type { DatabaseChatTool } from "@dayhaysoos/convex-database-chat/tools";
 const SYSTEM_PROMPT = `You are a helpful e-commerce inventory assistant. You help store managers understand their product inventory and find items.
 
 You have access to tools that let you:
-- Search products by name, category, or price range
+- Count products exactly using standard result metadata
+- List products with cursor pagination and standard result metadata
 - Run semantic search for fuzzy, concept-based queries
 - Get overall inventory statistics
 - Find low-stock products that need reordering
@@ -21,6 +32,8 @@ Available categories: electronics, clothing, home, sports
 
 When answering:
 - Be concise and use specific numbers from the data
+- Use standard count/list/semantic tools for normal product questions
+- Use legacy/raw tools only when the user explicitly asks to test compatibility
 - Always include product links using the viewUrl field: [Product Name](viewUrl)
 - Format prices with $ symbol (e.g., $29.99)
 - If stock is low (< 10), highlight it with "⚠️ Low Stock"
@@ -39,14 +52,55 @@ Example response format:
 type ToolParameters = DatabaseChatTool["parameters"];
 type ToolDefinition = DatabaseChatTool;
 
+const PRODUCT_CATEGORIES = [
+  "electronics",
+  "clothing",
+  "home",
+  "sports",
+] as const;
+const PRODUCT_FILTERS = {
+  searchQuery: stringFilter({
+    description: "Text to search in product name or description.",
+  }),
+  category: enumFilter({
+    values: PRODUCT_CATEGORIES,
+    description: "Product category.",
+  }),
+  minPrice: numberFilter({
+    min: 0,
+    description: "Minimum product price.",
+  }),
+  maxPrice: numberFilter({
+    min: 0,
+    description: "Maximum product price.",
+  }),
+  inStockOnly: booleanFilter({
+    description: "Only include products with stock above zero.",
+  }),
+} as const;
+const SEMANTIC_FILTERS = {
+  category: enumFilter({
+    values: PRODUCT_CATEGORIES,
+    description: "Product category.",
+  }),
+  inStockOnly: booleanFilter({
+    description: "Only include products with stock above zero.",
+  }),
+} as const;
+const STORE_CONTEXT = {
+  storeId: injectedString({
+    description: "Current demo store id injected by the app.",
+  }),
+} as const;
+
 const TOOL_SPECS: Record<
   string,
   { name: string; description: string; parameters: ToolParameters }
 > = {
-  searchProducts: {
-    name: "searchProducts",
+  rawSearchProducts: {
+    name: "rawSearchProducts",
     description:
-      "Search products by name, description, category, or price range. Use this to find specific products or browse inventory.",
+      "Legacy raw product search with top-level filters. Use only when the user explicitly asks to test raw or backwards-compatible search behavior.",
     parameters: {
       type: "object",
       properties: {
@@ -57,7 +111,7 @@ const TOOL_SPECS: Record<
         category: {
           type: "string",
           description: "Filter by category",
-          enum: ["electronics", "clothing", "home", "sports"],
+          enum: [...PRODUCT_CATEGORIES],
         },
         minPrice: {
           type: "number",
@@ -108,7 +162,7 @@ const TOOL_SPECS: Record<
 };
 
 const SEMANTIC_TOOL_DESCRIPTION =
-  "Semantic search across product names and descriptions. Use for fuzzy queries like 'home office setup' or 'travel essentials'.";
+  "Standard semantic search across product names and descriptions. Returns sampled top-K result metadata; use for fuzzy queries like 'home office setup' or 'travel essentials'.";
 
 let toolsPromise: Promise<ToolDefinition[]> | null = null;
 
@@ -116,23 +170,65 @@ async function getTools(): Promise<ToolDefinition[]> {
   if (!toolsPromise) {
     toolsPromise = (async () => {
       const chatToolsApi = api.chatTools as any;
-      const [searchHandle, semanticHandle, statsHandle, lowStockHandle] =
-        (await Promise.all([
-          createFunctionHandle(api.chatTools.searchProducts),
-          createFunctionHandle(chatToolsApi.semanticSearchProducts),
-          createFunctionHandle(api.chatTools.getProductStats),
-          createFunctionHandle(api.chatTools.getLowStockProducts),
-        ])) as string[];
+      const [
+        countHandle,
+        listHandle,
+        semanticHandle,
+        rawSearchHandle,
+        rawSemanticHandle,
+        statsHandle,
+        lowStockHandle,
+      ] = (await Promise.all([
+        createFunctionHandle(api.chatTools.countProducts),
+        createFunctionHandle(api.chatTools.listProducts),
+        createFunctionHandle(chatToolsApi.semanticSearchProductsStandard),
+        createFunctionHandle(api.chatTools.searchProducts),
+        createFunctionHandle(chatToolsApi.semanticSearchProducts),
+        createFunctionHandle(api.chatTools.getProductStats),
+        createFunctionHandle(api.chatTools.getLowStockProducts),
+      ])) as string[];
 
       return [
-        {
-          ...TOOL_SPECS.searchProducts,
-          handler: searchHandle,
-        },
-        defineVectorSearchTool({
+        defineCountTool({
+          name: "countProducts",
+          description:
+            "Count products exactly for factual total/count questions. Filters must be nested under filters.",
+          handler: countHandle,
+          filters: PRODUCT_FILTERS,
+          injectedArgs: STORE_CONTEXT,
+        }),
+        definePaginatedListTool({
+          name: "listProducts",
+          description:
+            "List products with deterministic cursor pagination. Use for browsing, filtered lists, and immediate show-more follow-ups.",
+          handler: listHandle,
+          filters: PRODUCT_FILTERS,
+          injectedArgs: STORE_CONTEXT,
+          pagination: {
+            defaultLimit: 5,
+            maxLimit: 20,
+          },
+        }),
+        defineSemanticSearchTool({
           name: "semanticSearchProducts",
           description: SEMANTIC_TOOL_DESCRIPTION,
           handler: semanticHandle,
+          filters: SEMANTIC_FILTERS,
+          injectedArgs: STORE_CONTEXT,
+          limit: {
+            defaultLimit: 5,
+            maxLimit: 12,
+          },
+        }),
+        {
+          ...TOOL_SPECS.rawSearchProducts,
+          handler: rawSearchHandle,
+        },
+        defineVectorSearchTool({
+          name: "rawSemanticSearchProducts",
+          description:
+            "Legacy raw semantic search compatibility path. Returns a raw array instead of the standard result contract; use only when explicitly requested.",
+          handler: rawSemanticHandle,
         }),
         {
           ...TOOL_SPECS.getProductStats,
@@ -224,13 +320,13 @@ export const getStreamState = query({
       status: v.union(
         v.literal("streaming"),
         v.literal("finished"),
-        v.literal("aborted")
+        v.literal("aborted"),
       ),
       startedAt: v.number(),
       endedAt: v.optional(v.number()),
       abortReason: v.optional(v.string()),
     }),
-    v.null()
+    v.null(),
   ),
   handler: async (ctx, args) => {
     const result = await ctx.runQuery(streamApi.getStream, {
@@ -259,7 +355,7 @@ export const getStreamDeltas = query({
             v.literal("text-delta"),
             v.literal("tool-call"),
             v.literal("tool-result"),
-            v.literal("error")
+            v.literal("error"),
           ),
           text: v.optional(v.string()),
           toolCallId: v.optional(v.string()),
@@ -267,9 +363,9 @@ export const getStreamDeltas = query({
           args: v.optional(v.string()),
           result: v.optional(v.string()),
           error: v.optional(v.string()),
-        })
+        }),
       ),
-    })
+    }),
   ),
   handler: async (ctx, args) => {
     return await ctx.runQuery(streamApi.listDeltas, {
@@ -339,6 +435,9 @@ export const sendMessage = action({
         systemPrompt: SYSTEM_PROMPT,
         toolGuidance: "auto",
         tools,
+        toolContext: {
+          storeId: "demo-store",
+        },
       },
     })) as { success: boolean; content?: string; error?: string };
 

--- a/example/convex/chat.ts
+++ b/example/convex/chat.ts
@@ -3,6 +3,7 @@ import { createFunctionHandle } from "convex/server";
 import { action, mutation, query } from "./_generated/server";
 import { components, api } from "./_generated/api";
 import { defineVectorSearchTool } from "@dayhaysoos/convex-database-chat/vector";
+import type { DatabaseChatTool } from "@dayhaysoos/convex-database-chat/tools";
 
 // =============================================================================
 // System Prompt
@@ -35,27 +36,8 @@ Example response format:
 // Tool Definitions
 // =============================================================================
 
-type ToolParameters = {
-  type: "object";
-  properties: Record<
-    string,
-    {
-      type: "string" | "number" | "boolean" | "array" | "object";
-      description?: string;
-      enum?: string[];
-      items?: { type: "string" | "number" | "boolean" | "array" | "object" };
-    }
-  >;
-  required?: string[];
-};
-
-type ToolDefinition = {
-  name: string;
-  description: string;
-  parameters: ToolParameters;
-  handler: string;
-  handlerType?: "query" | "mutation" | "action";
-};
+type ToolParameters = DatabaseChatTool["parameters"];
+type ToolDefinition = DatabaseChatTool;
 
 const TOOL_SPECS: Record<
   string,
@@ -355,6 +337,7 @@ export const sendMessage = action({
         apiKey,
         model: "anthropic/claude-sonnet-4",
         systemPrompt: SYSTEM_PROMPT,
+        toolGuidance: "auto",
         tools,
       },
     })) as { success: boolean; content?: string; error?: string };

--- a/example/convex/chatTools.ts
+++ b/example/convex/chatTools.ts
@@ -6,6 +6,7 @@ import {
   formatVectorResults,
   generateEmbedding,
 } from "@dayhaysoos/convex-database-chat/vector";
+import type { DatabaseChatToolResult } from "@dayhaysoos/convex-database-chat/resultContract";
 
 type ProductSummary = {
   _id: Id<"products">;
@@ -16,14 +17,193 @@ type ProductSummary = {
   stock: number;
 };
 
-type ProductSearchResult = ProductSummary & {
+type ProductSearchResult = {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  price: number;
+  stock: number;
+  inStock: boolean;
+  viewUrl: string;
+  score?: number;
+};
+
+type LegacyVectorProductResult = ProductSummary & {
+  id: string;
   inStock: boolean;
   viewUrl: string;
 };
 
+type ProductFilters = {
+  searchQuery?: string;
+  category?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  inStockOnly?: boolean;
+};
+
+const DEFAULT_STORE_ID = "demo-store";
+const DEFAULT_STORE_LABEL = "Demo Store";
+const DEFAULT_LIST_LIMIT = 5;
+const MAX_LIST_LIMIT = 20;
+const DEFAULT_SEMANTIC_LIMIT = 5;
+const MAX_SEMANTIC_LIMIT = 12;
+
+const productRowValidator = v.object({
+  id: v.string(),
+  name: v.string(),
+  description: v.string(),
+  category: v.string(),
+  price: v.number(),
+  stock: v.number(),
+  inStock: v.boolean(),
+  viewUrl: v.string(),
+  score: v.optional(v.number()),
+});
+
+const resultMetaValidator = v.object({
+  scope: v.object({
+    type: v.string(),
+    id: v.optional(v.string()),
+    label: v.optional(v.string()),
+  }),
+  appliedFilters: v.optional(v.any()),
+  count: v.optional(v.number()),
+  returned: v.number(),
+  exhaustive: v.boolean(),
+  truncated: v.boolean(),
+  truncationReason: v.optional(v.string()),
+  sampled: v.boolean(),
+  sampleMethod: v.optional(v.string()),
+  pagination: v.optional(
+    v.object({
+      cursor: v.optional(v.union(v.string(), v.null())),
+      hasMore: v.boolean(),
+      nextCursor: v.optional(v.union(v.string(), v.null())),
+      pageSize: v.optional(v.number()),
+    }),
+  ),
+});
+
+const productResultContractValidator = v.object({
+  data: v.array(productRowValidator),
+  meta: resultMetaValidator,
+});
+
+const productFiltersValidator = v.object({
+  searchQuery: v.optional(v.string()),
+  category: v.optional(v.string()),
+  minPrice: v.optional(v.number()),
+  maxPrice: v.optional(v.number()),
+  inStockOnly: v.optional(v.boolean()),
+});
+
+function normalizeFilters(filters: ProductFilters = {}): ProductFilters {
+  const normalized: ProductFilters = {};
+
+  if (filters.searchQuery?.trim()) {
+    normalized.searchQuery = filters.searchQuery.trim();
+  }
+  if (filters.category?.trim()) {
+    normalized.category = filters.category.trim().toLowerCase();
+  }
+  if (filters.minPrice !== undefined) {
+    normalized.minPrice = filters.minPrice;
+  }
+  if (filters.maxPrice !== undefined) {
+    normalized.maxPrice = filters.maxPrice;
+  }
+  if (filters.inStockOnly !== undefined) {
+    normalized.inStockOnly = filters.inStockOnly;
+  }
+
+  return normalized;
+}
+
+function applyProductFilters<T extends ProductSummary>(
+  products: T[],
+  filters: ProductFilters,
+): T[] {
+  let filtered = products;
+
+  if (filters.category) {
+    filtered = filtered.filter(
+      (product) => product.category.toLowerCase() === filters.category,
+    );
+  }
+
+  if (filters.minPrice !== undefined) {
+    filtered = filtered.filter((product) => product.price >= filters.minPrice!);
+  }
+
+  if (filters.maxPrice !== undefined) {
+    filtered = filtered.filter((product) => product.price <= filters.maxPrice!);
+  }
+
+  if (filters.inStockOnly) {
+    filtered = filtered.filter((product) => product.stock > 0);
+  }
+
+  if (filters.searchQuery) {
+    const query = filters.searchQuery.toLowerCase();
+    filtered = filtered.filter(
+      (product) =>
+        product.name.toLowerCase().includes(query) ||
+        product.description.toLowerCase().includes(query),
+    );
+  }
+
+  return filtered;
+}
+
+function productToResultRow(
+  product: ProductSummary,
+  score?: number,
+): ProductSearchResult {
+  const row: ProductSearchResult = {
+    id: product._id,
+    name: product.name,
+    description: product.description,
+    category: product.category,
+    price: product.price,
+    stock: product.stock,
+    inStock: product.stock > 0,
+    viewUrl: `/products/${product._id}`,
+  };
+  if (score !== undefined) {
+    row.score = score;
+  }
+  return row;
+}
+
+function clampLimit(
+  requestedLimit: number | undefined,
+  defaultLimit: number,
+  maxLimit: number,
+): number {
+  return Math.max(1, Math.min(requestedLimit ?? defaultLimit, maxLimit));
+}
+
+function parseCursor(cursor: string | undefined): number {
+  if (!cursor) {
+    return 0;
+  }
+  const parsed = Number.parseInt(cursor, 10);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function scopeForStore(storeId: string | undefined) {
+  return {
+    type: "store",
+    id: storeId ?? DEFAULT_STORE_ID,
+    label: DEFAULT_STORE_LABEL,
+  };
+}
+
 /**
- * Search products by various filters.
- * Used by the LLM to find products matching user queries.
+ * Legacy raw product search with top-level arguments.
+ * Kept in the example to verify backwards-compatible raw tool behavior.
  */
 export const searchProducts = query({
   args: {
@@ -33,6 +213,7 @@ export const searchProducts = query({
     maxPrice: v.optional(v.number()),
     inStockOnly: v.optional(v.boolean()),
     limit: v.optional(v.number()),
+    storeId: v.optional(v.string()),
   },
   returns: v.array(
     v.object({
@@ -47,48 +228,91 @@ export const searchProducts = query({
     }),
   ),
   handler: async (ctx, args) => {
-    const limit = Math.min(args.limit ?? 20, 50);
-    let products = await ctx.db.query("products").collect();
+    const limit = clampLimit(args.limit, 20, 50);
+    const products = await ctx.db.query("products").collect();
+    const filters = normalizeFilters(args);
+    return applyProductFilters(products, filters)
+      .slice(0, limit)
+      .map((product) => productToResultRow(product));
+  },
+});
 
-    // Filter by category
-    if (args.category) {
-      const cat = args.category.toLowerCase();
-      products = products.filter((p) => p.category.toLowerCase() === cat);
-    }
+/**
+ * Exact count tool using the standard DatabaseChat result contract.
+ */
+export const countProducts = query({
+  args: {
+    filters: v.optional(productFiltersValidator),
+    storeId: v.string(),
+  },
+  returns: productResultContractValidator,
+  handler: async (
+    ctx,
+    args,
+  ): Promise<DatabaseChatToolResult<ProductSearchResult>> => {
+    const products = await ctx.db.query("products").collect();
+    const filters = normalizeFilters(args.filters);
+    const count = applyProductFilters(products, filters).length;
 
-    // Filter by price range
-    if (args.minPrice !== undefined) {
-      products = products.filter((p) => p.price >= args.minPrice!);
-    }
-    if (args.maxPrice !== undefined) {
-      products = products.filter((p) => p.price <= args.maxPrice!);
-    }
+    return {
+      data: [],
+      meta: {
+        scope: scopeForStore(args.storeId),
+        appliedFilters: filters,
+        count,
+        returned: 0,
+        exhaustive: true,
+        truncated: false,
+        sampled: false,
+      },
+    };
+  },
+});
 
-    // Filter by stock
-    if (args.inStockOnly) {
-      products = products.filter((p) => p.stock > 0);
-    }
+/**
+ * Deterministic cursor-paginated list using the standard result contract.
+ */
+export const listProducts = query({
+  args: {
+    filters: v.optional(productFiltersValidator),
+    limit: v.optional(v.number()),
+    cursor: v.optional(v.string()),
+    storeId: v.string(),
+  },
+  returns: productResultContractValidator,
+  handler: async (
+    ctx,
+    args,
+  ): Promise<DatabaseChatToolResult<ProductSearchResult>> => {
+    const products = await ctx.db.query("products").collect();
+    const filters = normalizeFilters(args.filters);
+    const matchingProducts = applyProductFilters(products, filters);
+    const offset = parseCursor(args.cursor);
+    const limit = clampLimit(args.limit, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT);
+    const page = matchingProducts.slice(offset, offset + limit);
+    const returned = page.length;
+    const nextOffset = offset + returned;
+    const hasMore = nextOffset < matchingProducts.length;
 
-    // Filter by search query (name or description)
-    if (args.searchQuery) {
-      const q = args.searchQuery.toLowerCase();
-      products = products.filter(
-        (p) =>
-          p.name.toLowerCase().includes(q) ||
-          p.description.toLowerCase().includes(q),
-      );
-    }
-
-    return products.slice(0, limit).map((p) => ({
-      id: p._id,
-      name: p.name,
-      description: p.description,
-      category: p.category,
-      price: p.price,
-      stock: p.stock,
-      inStock: p.stock > 0,
-      viewUrl: `/products/${p._id}`,
-    }));
+    return {
+      data: page.map((product) => productToResultRow(product)),
+      meta: {
+        scope: scopeForStore(args.storeId),
+        appliedFilters: filters,
+        count: matchingProducts.length,
+        returned,
+        exhaustive: !hasMore,
+        truncated: hasMore,
+        ...(hasMore ? { truncationReason: "row_limit" } : {}),
+        sampled: false,
+        pagination: {
+          cursor: args.cursor ?? null,
+          hasMore,
+          nextCursor: hasMore ? String(nextOffset) : null,
+          pageSize: limit,
+        },
+      },
+    };
   },
 });
 
@@ -100,6 +324,7 @@ export const semanticSearchProducts = action({
   args: {
     query: v.string(),
     limit: v.optional(v.number()),
+    storeId: v.optional(v.string()),
   },
   returns: v.array(
     v.object({
@@ -139,8 +364,9 @@ export const semanticSearchProducts = action({
       ids: results.map((result) => result._id),
     })) as ProductSummary[];
 
-    const docsWithUrls: ProductSearchResult[] = docs.map((doc) => ({
+    const docsWithUrls: LegacyVectorProductResult[] = docs.map((doc) => ({
       ...doc,
+      id: doc._id,
       inStock: doc.stock > 0,
       viewUrl: `/products/${doc._id}`,
     }));
@@ -156,7 +382,7 @@ export const semanticSearchProducts = action({
     ] as const;
 
     return formatVectorResults<
-      ProductSearchResult,
+      LegacyVectorProductResult,
       Id<"products">,
       typeof fields
     >(results, docsWithUrls, {
@@ -167,11 +393,95 @@ export const semanticSearchProducts = action({
 });
 
 /**
+ * Semantic search using the standard result contract.
+ * This path exercises sampled top-K metadata and automatic prompt guidance.
+ */
+export const semanticSearchProductsStandard = action({
+  args: {
+    query: v.string(),
+    filters: v.optional(
+      v.object({
+        category: v.optional(v.string()),
+        inStockOnly: v.optional(v.boolean()),
+      }),
+    ),
+    limit: v.optional(v.number()),
+    storeId: v.string(),
+  },
+  returns: productResultContractValidator,
+  handler: async (
+    ctx,
+    args,
+  ): Promise<DatabaseChatToolResult<ProductSearchResult>> => {
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    if (!apiKey) {
+      throw new Error("OPENROUTER_API_KEY not configured");
+    }
+
+    const embedding = await generateEmbedding({
+      apiKey,
+      text: args.query,
+    });
+
+    const limit = clampLimit(
+      args.limit,
+      DEFAULT_SEMANTIC_LIMIT,
+      MAX_SEMANTIC_LIMIT,
+    );
+    const filters = normalizeFilters(args.filters);
+    const vectorLimit = filters.inStockOnly ? Math.min(limit * 4, 256) : limit;
+    const results = await ctx.vectorSearch(
+      "products",
+      "by_description_embedding",
+      {
+        vector: embedding,
+        limit: vectorLimit,
+        ...(filters.category
+          ? { filter: (q) => q.eq("category", filters.category!) }
+          : {}),
+      },
+    );
+
+    const chatToolsApi = api.chatTools as any;
+    const docs = (await ctx.runQuery(chatToolsApi.fetchProductsByIds, {
+      ids: results.map((result) => result._id),
+    })) as ProductSummary[];
+    const scoresById = new Map(
+      results.map((result) => [result._id, result._score]),
+    );
+    const data = applyProductFilters(docs, filters)
+      .slice(0, limit)
+      .map((product) =>
+        productToResultRow(product, scoresById.get(product._id)),
+      );
+
+    return {
+      data,
+      meta: {
+        scope: scopeForStore(args.storeId),
+        appliedFilters: {
+          query: args.query,
+          ...filters,
+        },
+        returned: data.length,
+        exhaustive: false,
+        truncated: true,
+        truncationReason: "semantic_top_k_limit",
+        sampled: true,
+        sampleMethod: "semantic_top_k",
+      },
+    };
+  },
+});
+
+/**
  * Get overall product statistics.
  * Useful for inventory overview questions.
  */
 export const getProductStats = query({
-  args: {},
+  args: {
+    storeId: v.optional(v.string()),
+  },
   returns: v.object({
     totalProducts: v.number(),
     totalValue: v.number(),
@@ -249,6 +559,7 @@ export const getProductStats = query({
 export const getLowStockProducts = query({
   args: {
     threshold: v.optional(v.number()),
+    storeId: v.optional(v.string()),
   },
   returns: v.array(
     v.object({

--- a/example/convex/schema.ts
+++ b/example/convex/schema.ts
@@ -17,6 +17,7 @@ export default defineSchema({
     .vectorIndex("by_description_embedding", {
       vectorField: "embedding",
       dimensions: DEFAULT_EMBEDDING_DIMENSIONS,
+      filterFields: ["category"],
     }),
 
   rateLimits: defineTable({

--- a/example/convex/seed.ts
+++ b/example/convex/seed.ts
@@ -4,8 +4,16 @@ import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { generateEmbedding } from "@dayhaysoos/convex-database-chat/vector";
 
-const PRODUCTS = [
-  // Electronics (13 products)
+type ProductSeed = {
+  name: string;
+  description: string;
+  category: string;
+  price: number;
+  stock: number;
+};
+
+const BASE_PRODUCTS: ProductSeed[] = [
+  // Electronics base catalog
   {
     name: "Wireless Earbuds Pro",
     description:
@@ -99,7 +107,7 @@ const PRODUCTS = [
     stock: 34,
   },
 
-  // Clothing (12 products)
+  // Clothing base catalog
   {
     name: "Cotton T-Shirt Classic",
     description: "100% cotton crew neck t-shirt, multiple colors",
@@ -185,7 +193,7 @@ const PRODUCTS = [
     stock: 7,
   },
 
-  // Home (13 products)
+  // Home base catalog
   {
     name: "Coffee Maker Drip",
     description: "12-cup programmable drip coffee maker",
@@ -278,7 +286,7 @@ const PRODUCTS = [
     stock: 112,
   },
 
-  // Sports (12 products)
+  // Sports base catalog
   {
     name: "Yoga Mat Premium",
     description: "Extra thick non-slip yoga mat 72x24 inches",
@@ -365,21 +373,88 @@ const PRODUCTS = [
   },
 ];
 
+const PRODUCT_VARIANTS = [
+  {
+    suffix: "Value Pack",
+    description: "Value-priced option for budget-sensitive replenishment.",
+    priceMultiplier: 0.82,
+    stockOffset: 64,
+  },
+  {
+    suffix: "Premium Pack",
+    description: "Higher-margin configuration for premium assortment planning.",
+    priceMultiplier: 1.24,
+    stockOffset: 18,
+  },
+  {
+    suffix: "Bulk Case",
+    description: "Bulk replenishment case for larger store orders.",
+    priceMultiplier: 1.58,
+    stockOffset: 132,
+  },
+  {
+    suffix: "Seasonal Run",
+    description: "Limited seasonal run for promotion and markdown testing.",
+    priceMultiplier: 1.08,
+    stockOffset: -8,
+  },
+] as const;
+
+function roundPrice(price: number): number {
+  return Math.round(price * 100) / 100;
+}
+
+function buildVariantProduct(
+  product: ProductSeed,
+  productIndex: number,
+  variant: (typeof PRODUCT_VARIANTS)[number],
+  variantIndex: number,
+): ProductSeed {
+  const stockJitter = ((productIndex + 1) * (variantIndex + 3)) % 37;
+
+  return {
+    name: `${product.name} ${variant.suffix}`,
+    description: `${product.description}. ${variant.description}`,
+    category: product.category,
+    price: roundPrice(product.price * variant.priceMultiplier),
+    stock: Math.max(0, product.stock + variant.stockOffset + stockJitter - 18),
+  };
+}
+
+const GENERATED_PRODUCTS = BASE_PRODUCTS.flatMap((product, productIndex) =>
+  PRODUCT_VARIANTS.map((variant, variantIndex) =>
+    buildVariantProduct(product, productIndex, variant, variantIndex),
+  ),
+);
+
+const PRODUCTS = [...BASE_PRODUCTS, ...GENERATED_PRODUCTS] as const;
+
 export const seedProducts = mutation({
   args: {},
   handler: async (ctx) => {
-    // Check if products already exist
-    const existing = await ctx.db.query("products").first();
-    if (existing) {
-      return { message: "Products already seeded", count: 0 };
-    }
+    const existingProducts = await ctx.db.query("products").collect();
+    const existingNames = new Set(
+      existingProducts.map((product) => product.name),
+    );
+    let inserted = 0;
 
-    // Insert all products
     for (const product of PRODUCTS) {
+      if (existingNames.has(product.name)) {
+        continue;
+      }
       await ctx.db.insert("products", product);
+      existingNames.add(product.name);
+      inserted += 1;
     }
 
-    return { message: "Products seeded successfully", count: PRODUCTS.length };
+    return {
+      message:
+        inserted === 0
+          ? "Products already seeded"
+          : "Products seeded successfully",
+      count: inserted,
+      total: existingProducts.length + inserted,
+    };
   },
 });
 
@@ -458,7 +533,11 @@ export const generateProductEmbeddings = action({
     let skipped = 0;
 
     for (const product of products.slice(0, limit)) {
-      if (!args.overwrite && product.embedding && product.embedding.length > 0) {
+      if (
+        !args.overwrite &&
+        product.embedding &&
+        product.embedding.length > 0
+      ) {
         skipped += 1;
         continue;
       }

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ecommerce-chat-demo",
       "version": "1.0.0",
       "dependencies": {
-        "@dayhaysoos/convex-database-chat": "^0.2.0-alpha.1",
+        "@dayhaysoos/convex-database-chat": "file:..",
         "@fingerprintjs/fingerprintjs": "^4.5.1",
         "convex": "^1.17.0",
         "react": "^18.3.1",
@@ -27,8 +27,7 @@
     },
     "..": {
       "name": "@dayhaysoos/convex-database-chat",
-      "version": "0.2.0-alpha.1",
-      "extraneous": true,
+      "version": "0.3.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -338,19 +337,8 @@
       }
     },
     "node_modules/@dayhaysoos/convex-database-chat": {
-      "version": "0.2.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@dayhaysoos/convex-database-chat/-/convex-database-chat-0.2.0-alpha.1.tgz",
-      "integrity": "sha512-offkb4PKmDLh7PIHCbkVfQ8XljE9Tq8JxU6VXGAyDpHfvU78KVcVOPG0z1fV8BPP1SqW5ZrR0w++sxDij0A/Zg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "convex": "^1.17.0",
-        "react": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.0",

--- a/example/package.json
+++ b/example/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "concurrently -k \"npm run dev:ui\" \"npm run convex\"",
+    "predev": "npm --prefix .. run build",
+    "dev": "concurrently -k \"npm run dev:package\" \"npm run dev:ui\" \"npm run convex\"",
+    "dev:package": "npm --prefix .. run build:watch",
     "dev:ui": "vite --port 3000 --strictPort",
+    "prebuild": "npm --prefix .. run build",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "start": "serve dist -s -l ${PORT:-3000}",

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "seed:embeddings": "convex run seed:generateProductEmbeddings"
   },
   "dependencies": {
-    "@dayhaysoos/convex-database-chat": "^0.3.0-alpha.0",
+    "@dayhaysoos/convex-database-chat": "file:..",
     "@fingerprintjs/fingerprintjs": "^4.5.1",
     "convex": "^1.17.0",
     "react": "^18.3.1",

--- a/example/src/App.css
+++ b/example/src/App.css
@@ -6,8 +6,9 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, sans-serif;
   background: #0f0f0f;
   min-height: 100vh;
   color: #fafafa;
@@ -542,6 +543,29 @@ body {
   word-break: break-word;
 }
 
+.chat-tools-meta {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.chat-tools-meta span,
+.chat-tools-meta.error {
+  color: #a1a1aa;
+  background: #18181b;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid #3f3f46;
+  font-size: 0.68rem;
+}
+
+.chat-tools-meta.error {
+  color: #fca5a5;
+  border-color: #7f1d1d;
+  border-radius: 6px;
+}
+
 /* Welcome message */
 .chat-welcome {
   text-align: center;
@@ -569,17 +593,25 @@ body {
 
 .chat-welcome li {
   background: #27272a;
-  padding: 8px 12px;
   border-radius: 6px;
-  font-size: 0.85rem;
-  color: #f97316;
-  cursor: default;
   border: 1px solid #3f3f46;
   transition: border-color 0.2s;
 }
 
 .chat-welcome li:hover {
   border-color: #f97316;
+}
+
+.chat-welcome li button {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: #f97316;
+  cursor: pointer;
+  padding: 8px 12px;
+  font: inherit;
+  font-size: 0.85rem;
+  text-align: left;
 }
 
 .rate-limit-warning {

--- a/example/src/components/Chat.tsx
+++ b/example/src/components/Chat.tsx
@@ -30,6 +30,127 @@ interface StreamDelta {
   }>;
 }
 
+interface ToolResultSummary {
+  type: "standard" | "raw" | "error";
+  count?: number;
+  returned?: number;
+  sampled?: boolean;
+  truncated?: boolean;
+  hasMore?: boolean;
+  nextCursor?: string | null;
+  scope?: string;
+  rawShape?: string;
+  error?: string;
+}
+
+const SUGGESTED_PROMPTS = [
+  "How many electronics are under $50?",
+  "Show me 5 electronics under $50.",
+  "Show more.",
+  "Find products for a home office setup.",
+  "Use the legacy raw search tool for sports products.",
+  "What is the inventory overview?",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function summarizeToolResult(result: string): ToolResultSummary {
+  try {
+    const parsed = JSON.parse(result);
+
+    if (isRecord(parsed) && typeof parsed.error === "string") {
+      return { type: "error", error: parsed.error };
+    }
+
+    if (
+      isRecord(parsed) &&
+      Array.isArray(parsed.data) &&
+      isRecord(parsed.meta)
+    ) {
+      const pagination = isRecord(parsed.meta.pagination)
+        ? parsed.meta.pagination
+        : undefined;
+      const scope = isRecord(parsed.meta.scope)
+        ? [
+            parsed.meta.scope.label,
+            parsed.meta.scope.type,
+            parsed.meta.scope.id,
+          ]
+            .filter((part): part is string => typeof part === "string")
+            .join(" / ")
+        : undefined;
+
+      return {
+        type: "standard",
+        count:
+          typeof parsed.meta.count === "number" ? parsed.meta.count : undefined,
+        returned:
+          typeof parsed.meta.returned === "number"
+            ? parsed.meta.returned
+            : parsed.data.length,
+        sampled:
+          typeof parsed.meta.sampled === "boolean"
+            ? parsed.meta.sampled
+            : undefined,
+        truncated:
+          typeof parsed.meta.truncated === "boolean"
+            ? parsed.meta.truncated
+            : undefined,
+        hasMore:
+          typeof pagination?.hasMore === "boolean"
+            ? pagination.hasMore
+            : undefined,
+        nextCursor:
+          typeof pagination?.nextCursor === "string" ||
+          pagination?.nextCursor === null
+            ? pagination.nextCursor
+            : undefined,
+        scope,
+      };
+    }
+
+    if (Array.isArray(parsed)) {
+      return { type: "raw", returned: parsed.length, rawShape: "array" };
+    }
+
+    return {
+      type: "raw",
+      rawShape: isRecord(parsed) ? "object" : typeof parsed,
+    };
+  } catch {
+    return { type: "raw", rawShape: "unparsed" };
+  }
+}
+
+function ToolResultMetadata({ summary }: { summary: ToolResultSummary }) {
+  if (summary.type === "error") {
+    return <div className="chat-tools-meta error">{summary.error}</div>;
+  }
+
+  const items = [
+    summary.type === "standard" ? "standard" : `raw ${summary.rawShape ?? ""}`,
+    summary.count !== undefined ? `count ${summary.count}` : null,
+    summary.returned !== undefined ? `returned ${summary.returned}` : null,
+    summary.sampled !== undefined ? `sampled ${String(summary.sampled)}` : null,
+    summary.truncated !== undefined
+      ? `truncated ${String(summary.truncated)}`
+      : null,
+    summary.hasMore !== undefined ? `hasMore ${String(summary.hasMore)}` : null,
+    summary.nextCursor ? `next ${summary.nextCursor}` : null,
+    summary.scope ? `scope ${summary.scope}` : null,
+  ].filter((item): item is string => Boolean(item));
+
+  return (
+    <div className="chat-tools-meta">
+      {items.map((item) => (
+        <span key={item}>{item}</span>
+      ))}
+    </div>
+  );
+}
+
 /**
  * Parse markdown-style links and bold text for rendering
  */
@@ -84,7 +205,7 @@ function useDeltaStreaming(conversationId: string | null) {
   // Subscribe to stream state
   const streamState = useQuery(
     api.chat.getStreamState,
-    conversationId ? { conversationId } : "skip"
+    conversationId ? { conversationId } : "skip",
   ) as StreamState | null | undefined;
 
   const streamId = streamState?.streamId ?? null;
@@ -103,7 +224,7 @@ function useDeltaStreaming(conversationId: string | null) {
   // Fetch deltas from cursor position
   const deltas = useQuery(
     api.chat.getStreamDeltas,
-    streamId && status === "streaming" ? { streamId, cursor } : "skip"
+    streamId && status === "streaming" ? { streamId, cursor } : "skip",
   ) as StreamDelta[] | undefined;
 
   // Accumulate new deltas with deduplication
@@ -114,7 +235,7 @@ function useDeltaStreaming(conversationId: string | null) {
 
     // Filter out already-processed deltas to prevent duplicates
     const newDeltas = deltas.filter(
-      (d) => d.start >= lastProcessedEndRef.current
+      (d) => d.start >= lastProcessedEndRef.current,
     );
 
     if (newDeltas.length === 0) {
@@ -169,7 +290,7 @@ export function Chat() {
   const [error, setError] = useState<string | null>(null);
   const [showTools, setShowTools] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  
+
   // Track if current request was aborted to ignore its completion
   const wasAbortedRef = useRef(false);
 
@@ -192,14 +313,19 @@ export function Chat() {
 
   const messages = useQuery(
     api.chat.getMessages,
-    conversationId ? { conversationId } : "skip"
+    conversationId ? { conversationId } : "skip",
   ) as Message[] | undefined;
 
-  const toolResultIds = new Set(
-    (messages ?? []).flatMap((msg) =>
-      msg.toolResults ? msg.toolResults.map((result) => result.toolCallId) : []
-    )
-  );
+  const toolResultSummaries = new Map<string, ToolResultSummary>();
+  for (const msg of messages ?? []) {
+    for (const result of msg.toolResults ?? []) {
+      toolResultSummaries.set(
+        result.toolCallId,
+        summarizeToolResult(result.result),
+      );
+    }
+  }
+  const toolResultIds = new Set(toolResultSummaries.keys());
 
   const toolCalls = (messages ?? []).flatMap((msg) =>
     msg.toolCalls
@@ -208,12 +334,13 @@ export function Chat() {
           name: call.name,
           args: call.arguments,
           createdAt: msg.createdAt,
+          result: toolResultSummaries.get(call.id),
         }))
-      : []
+      : [],
   );
 
   const displayMessages = (messages ?? []).filter(
-    (msg) => msg.role !== "tool" && !msg.toolCalls
+    (msg) => msg.role !== "tool" && !msg.toolCalls,
   );
 
   // Use delta-based streaming for efficient O(n) bandwidth
@@ -227,12 +354,11 @@ export function Chat() {
     maxDelayMs: 60,
   });
 
-
   // Create conversation on mount
   useEffect(() => {
     if (!conversationId) {
       createConversation({ externalId: "demo-user", title: "Demo Chat" }).then(
-        setConversationId
+        setConversationId,
       );
     }
   }, [conversationId, createConversation]);
@@ -249,7 +375,7 @@ export function Chat() {
     // Quick client-side check (server also enforces)
     if (!canSendMessage()) {
       setError(
-        `Rate limit reached. Resets in ${getResetTimeDisplay()}. This is a demo with limited usage.`
+        `Rate limit reached. Resets in ${getResetTimeDisplay()}. This is a demo with limited usage.`,
       );
       return;
     }
@@ -267,12 +393,12 @@ export function Chat() {
         message,
         fingerprint: fingerprint ?? undefined,
       });
-      
+
       // Ignore result if request was aborted
       if (wasAbortedRef.current) {
         return;
       }
-      
+
       if (!result.success) {
         // Don't show "Stream aborted" as an error - it's expected when user stops
         if (!result.error?.includes("aborted")) {
@@ -287,7 +413,8 @@ export function Chat() {
       if (wasAbortedRef.current) {
         return;
       }
-      const errorMessage = err instanceof Error ? err.message : "Failed to send message";
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to send message";
       // Don't show abort-related errors
       if (!errorMessage.toLowerCase().includes("abort")) {
         setError(errorMessage);
@@ -302,13 +429,13 @@ export function Chat() {
 
   const handleAbort = async () => {
     if (!conversationId || isStopping) return;
-    
+
     // Mark as aborted so handleSubmit ignores the result
     wasAbortedRef.current = true;
-    
+
     // Immediate feedback
     setIsStopping(true);
-    
+
     try {
       await abortStreamMutation({ conversationId, reason: "User cancelled" });
     } catch (err) {
@@ -350,9 +477,7 @@ export function Chat() {
                 </span>
               )}
               {isLocalDev && (
-                <span className="rate-limit-badge dev-mode">
-                  Dev Mode
-                </span>
+                <span className="rate-limit-badge dev-mode">Dev Mode</span>
               )}
             </div>
             <div className="chat-header-right">
@@ -387,8 +512,8 @@ export function Chat() {
               </div>
               {toolCalls.length === 0 ? (
                 <div className="chat-tools-empty">
-                  No tool calls yet. Ask a conceptual question to trigger
-                  semantic search.
+                  No tool calls yet. Ask about counts, lists, semantic search,
+                  or legacy raw tools.
                 </div>
               ) : (
                 <ul className="chat-tools-list">
@@ -410,6 +535,9 @@ export function Chat() {
                             ? `${call.args.slice(0, 140)}...`
                             : call.args}
                         </code>
+                        {call.result && (
+                          <ToolResultMetadata summary={call.result} />
+                        )}
                       </li>
                     ))}
                 </ul>
@@ -423,10 +551,16 @@ export function Chat() {
                 <h3>Welcome! 👋</h3>
                 <p>Ask me about the products in the database:</p>
                 <ul>
-                  <li>"Show me electronics under $50"</li>
-                  <li>"What products are low on stock?"</li>
-                  <li>"Give me an inventory overview"</li>
-                  <li>"Find running shoes"</li>
+                  {SUGGESTED_PROMPTS.map((prompt) => (
+                    <li key={prompt}>
+                      <button
+                        type="button"
+                        onClick={() => setInputValue(prompt)}
+                      >
+                        "{prompt}"
+                      </button>
+                    </li>
+                  ))}
                 </ul>
                 {isRateLimited && (
                   <div className="rate-limit-warning">
@@ -496,7 +630,9 @@ export function Chat() {
                   ? `Rate limit reached. Resets in ${getResetTimeDisplay()}`
                   : "Ask about products..."
               }
-              disabled={isLoading || isStreaming || !conversationId || isRateLimited}
+              disabled={
+                isLoading || isStreaming || !conversationId || isRateLimited
+              }
               className="chat-input"
             />
             {isLoading || isStreaming || isStopping ? (
@@ -513,9 +649,7 @@ export function Chat() {
               <button
                 type="submit"
                 disabled={
-                  !inputValue.trim() ||
-                  !conversationId ||
-                  isRateLimited
+                  !inputValue.trim() || !conversationId || isRateLimited
                 }
                 className="chat-submit"
               >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dayhaysoos/convex-database-chat",
-  "version": "0.3.0-alpha.1",
+  "version": "0.2.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dayhaysoos/convex-database-chat",
-      "version": "0.3.0-alpha.1",
+      "version": "0.2.0-rc.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,18 @@
       "types": "./dist/src/vector.d.ts",
       "import": "./dist/src/vector.js"
     },
+    "./resultContract": {
+      "types": "./dist/convex/component/resultContract.d.ts",
+      "import": "./dist/convex/component/resultContract.js"
+    },
+    "./tools": {
+      "types": "./dist/convex/component/tools.d.ts",
+      "import": "./dist/convex/component/tools.js"
+    },
+    "./toolGuidance": {
+      "types": "./dist/convex/component/toolGuidance.d.ts",
+      "import": "./dist/convex/component/toolGuidance.js"
+    },
     "./test": "./src/test.ts",
     "./_generated/component.js": {
       "types": "./dist/convex/component/_generated/component.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dayhaysoos/convex-database-chat",
-  "version": "0.3.0-alpha.1",
+  "version": "0.2.0-rc.0",
   "description": "A Convex component for adding natural language database queries to your app.",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -92,6 +92,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dayhaysoos/convex-database-chat"
+    "url": "git+https://github.com/dayhaysoos/convex-database-chat.git"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,4 +36,4 @@ export {
   type UseConversationsReturn,
   type UseSmoothTextOptions,
   type SmoothTextProps,
-} from "./react";
+} from "./react.js";

--- a/src/vector.test.ts
+++ b/src/vector.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { defineVectorSearchTool } from "./vector";
+
+describe("vector helpers", () => {
+  it("marks vector search tools as semantic search without claiming the standard result contract", () => {
+    const tool = defineVectorSearchTool({
+      name: "semanticSearchRecords",
+      description: "Search records by semantic relevance.",
+      handler: "handler_string",
+    });
+
+    expect(tool).toMatchObject({
+      handlerType: "action",
+      metadata: {
+        kind: "semantic_search",
+      },
+    });
+    expect(tool.metadata).not.toHaveProperty("resultContract");
+  });
+});

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -44,6 +44,11 @@ export type VectorSearchResult<IdType = string> = {
 /**
  * Tool definition compatible with DatabaseChat tools.
  */
+export type VectorToolMetadata = {
+  kind: "semantic_search";
+  resultContract?: "standard";
+};
+
 export interface VectorToolDefinition {
   /** Unique name for the tool (used by the LLM to call it). */
   name: string;
@@ -55,6 +60,8 @@ export interface VectorToolDefinition {
   handlerType?: "query" | "mutation" | "action";
   /** Convex function handle string to execute. */
   handler: string;
+  /** Reliability metadata consumed by DatabaseChat prompt guidance. */
+  metadata?: VectorToolMetadata;
 }
 
 /**
@@ -219,6 +226,9 @@ export function defineVectorSearchTool(
     description: options.description,
     handlerType: "action",
     handler: options.handler,
+    metadata: {
+      kind: "semantic_search",
+    },
     parameters: {
       type: "object",
       properties,


### PR DESCRIPTION
## Summary

Prepares and documents the result-contract tooling work for the `0.2.0-rc.0` release candidate.

## Feature summary

- Added standard tool result semantics for count, paginated list, and semantic search outputs using the `{ data, meta }` result envelope.
- Added typed tool builders: `defineCountTool`, `definePaginatedListTool`, and `defineSemanticSearchTool`.
- Added typed filter helpers and injected-arg helpers so model-visible filters stay nested under `filters` while app-provided context stays server-side.
- Added tool reliability metadata through `tool.metadata.kind` and `metadata.resultContract` so the component can reason about count, list, semantic, detail, and unknown tool behavior.
- Added automatic tool guidance that tells the LLM how to interpret count totals, cursor pagination, semantic top-K sampling, and standard result metadata.
- Changed `defineSemanticSearchTool` to default to `handlerType: "action"`, while still allowing explicit overrides for query-backed semantic tools.
- Updated the example app to exercise the new standard count/list/semantic tools alongside legacy raw tool compatibility.
- Expanded the example inventory to 250 products and added tool activity metadata in the UI for contract debugging.
- Updated the docs and README to cover result contracts, builder defaults, metadata, cursor pagination, semantic search semantics, injected args, and `toolGuidance`.
- Normalized package metadata for clean npm dry-runs and RC publishing.

## Validation

- `pnpm typecheck`
- `pnpm test --run`
- `pnpm build`
- `pnpm lint` after cleaning ignored docs generated dirs, with existing warnings only
- `npm run build` in `example`
- `npm run types:check` in `docs`
- `npm run build` in `docs`
- `git diff --check`
- `npm pack --json`
- `npm publish --dry-run --tag rc --access public`
- Installed the generated tarball in a temp project and imported all public subpaths

## Release note

Published as `@dayhaysoos/convex-database-chat@0.2.0-rc.0` under the npm `rc` dist-tag. The npm `latest` dist-tag remains on `0.3.0-alpha.1`.
